### PR TITLE
Made submodule use HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "pages"]
 	path = pages
-	url = git@github.com:Taywee/args.git
+	url = https://github.com/Taywee/args.git
 	branch = gh-pages


### PR DESCRIPTION
Hello,

thank you for your contributions. I want to be able to use args as a submodule at my workplace, however I don't want to force everyone to have a Github account with their SSH public key registered. So I suggest that your 'pages' submodule uses HTTPS instead of SSH.

Thanks,
Hannes Pétur