### PR TITLE
Subparsers help

### DIFF
--- a/test.cxx
+++ b/test.cxx
@@ -599,11 +599,11 @@ TEST_CASE("Hidden options are excluded from help", "[args]")
     args::ValueFlag<int> foo1(group, "foo", "foo", {'f', "foo"}, args::Options::Hidden);
     args::ValueFlag<int> bar2(group, "bar", "bar", {'b'});
 
-    auto desc = parser1.GetDescription("", "", "", "", 0);
+    auto desc = parser1.GetDescription(parser1.helpParams, 0);
     REQUIRE(desc.size() == 3);
-    REQUIRE(std::get<0>(desc[0]) == "b[bar]");
+    REQUIRE(std::get<0>(desc[0]) == "-b[bar]");
     REQUIRE(std::get<0>(desc[1]) == "group");
-    REQUIRE(std::get<0>(desc[2]) == "b[bar]");
+    REQUIRE(std::get<0>(desc[2]) == "-b[bar]");
 }
 
 TEST_CASE("Implicit values work as expected", "[args]")

--- a/test.cxx
+++ b/test.cxx
@@ -763,17 +763,36 @@ TEST_CASE("Subparser help works as expected", "[args]")
         c.Parse();
     });
 
+    p.Prog("git");
+
+    std::ostringstream s;
+
     auto d = p.GetDescription(p.helpParams, 0);
-    REQUIRE(d.size() == 3);
-    REQUIRE(std::get<0>(d[0]) == "-g");
-    REQUIRE(std::get<0>(d[1]) == "add");
-    REQUIRE(std::get<0>(d[2]) == "commit");
+    s << p;
+    REQUIRE(s.str() == R"(  git {OPTIONS}
+
+    git-like parser
+
+  OPTIONS:
+
+      -g                                global flag
+      add                               add file contents to the index
+      commit                            record changes to the repository
+
+)");
 
     p.ParseArgs(std::vector<std::string>{"add"});
-    d = p.GetDescription(p.helpParams, 0);
-    REQUIRE(d.size() == 2);
-    REQUIRE(std::get<0>(d[0]) == "add");
-    REQUIRE(std::get<0>(d[1]) == "-f");
+    s.str("");
+    s << p;
+    REQUIRE(s.str() == R"(  git add {OPTIONS}
+
+    add file contents to the index
+
+  OPTIONS:
+
+      -f                                flag
+
+)");
 }
 
 #undef ARGS_HXX

--- a/test.cxx
+++ b/test.cxx
@@ -793,6 +793,69 @@ TEST_CASE("Subparser help works as expected", "[args]")
       -f                                flag
 
 )");
+
+    p.ParseArgs(std::vector<std::string>{});
+    s.str("");
+    s << p;
+    REQUIRE(s.str() == R"(  git {OPTIONS}
+
+    git-like parser
+
+  OPTIONS:
+
+      -g                                global flag
+      add                               add file contents to the index
+      commit                            record changes to the repository
+
+)");
+
+
+    p.helpParams.showCommandChildren = true;
+    p.ParseArgs(std::vector<std::string>{});
+    s.str("");
+    s << p;
+    REQUIRE(s.str() == R"(  git {OPTIONS}
+
+    git-like parser
+
+  OPTIONS:
+
+      -g                                global flag
+      add                               add file contents to the index
+        -f                                flag
+      commit                            record changes to the repository
+        -f                                flag
+
+)");
+
+    commit.Epilog("epilog");
+    p.helpParams.showCommandFullHelp = true;
+    p.ParseArgs(std::vector<std::string>{});
+    s.str("");
+    s << p;
+    REQUIRE(s.str() == R"(  git {OPTIONS}
+
+    git-like parser
+
+  OPTIONS:
+
+      -g                                global flag
+      add {OPTIONS}
+
+        add file contents to the index
+
+        -f                                flag
+
+      commit {OPTIONS}
+
+        record changes to the repository
+
+        -f                                flag
+
+        epilog
+
+)");
+
 }
 
 #undef ARGS_HXX

--- a/test.cxx
+++ b/test.cxx
@@ -746,6 +746,36 @@ TEST_CASE("Subparser commands with kick-out flags work as expected", "[args]")
     REQUIRE((kickedOut == std::vector<std::string>{"A", "B", "C", "D"}));
 }
 
+TEST_CASE("Subparser help works as expected", "[args]")
+{
+    args::ArgumentParser p("git-like parser");
+    args::Flag g(p, "GLOBAL", "global flag", {'g'}, args::Options::Global);
+
+    args::Command add(p, "add", "add file contents to the index", [&](args::Subparser &c)
+    {
+        args::Flag flag(c, "FLAG", "flag", {'f'});
+        c.Parse();
+    });
+
+    args::Command commit(p, "commit", "record changes to the repository", [&](args::Subparser &c)
+    {
+        args::Flag flag(c, "FLAG", "flag", {'f'});
+        c.Parse();
+    });
+
+    auto d = p.GetDescription(p.helpParams, 0);
+    REQUIRE(d.size() == 3);
+    REQUIRE(std::get<0>(d[0]) == "-g");
+    REQUIRE(std::get<0>(d[1]) == "add");
+    REQUIRE(std::get<0>(d[2]) == "commit");
+
+    p.ParseArgs(std::vector<std::string>{"add"});
+    d = p.GetDescription(p.helpParams, 0);
+    REQUIRE(d.size() == 2);
+    REQUIRE(std::get<0>(d[0]) == "add");
+    REQUIRE(std::get<0>(d[1]) == "-f");
+}
+
 #undef ARGS_HXX
 #define ARGS_TESTNAMESPACE
 #define ARGS_NOEXCEPT

--- a/test.cxx
+++ b/test.cxx
@@ -769,7 +769,7 @@ TEST_CASE("Subparser help works as expected", "[args]")
 
     auto d = p.GetDescription(p.helpParams, 0);
     s << p;
-    REQUIRE(s.str() == R"(  git {OPTIONS}
+    REQUIRE(s.str() == R"(  git [COMMAND] {OPTIONS}
 
     git-like parser
 
@@ -797,7 +797,7 @@ TEST_CASE("Subparser help works as expected", "[args]")
     p.ParseArgs(std::vector<std::string>{});
     s.str("");
     s << p;
-    REQUIRE(s.str() == R"(  git {OPTIONS}
+    REQUIRE(s.str() == R"(  git [COMMAND] {OPTIONS}
 
     git-like parser
 
@@ -809,12 +809,11 @@ TEST_CASE("Subparser help works as expected", "[args]")
 
 )");
 
-
     p.helpParams.showCommandChildren = true;
     p.ParseArgs(std::vector<std::string>{});
     s.str("");
     s << p;
-    REQUIRE(s.str() == R"(  git {OPTIONS}
+    REQUIRE(s.str() == R"(  git [COMMAND] {OPTIONS}
 
     git-like parser
 
@@ -833,7 +832,7 @@ TEST_CASE("Subparser help works as expected", "[args]")
     p.ParseArgs(std::vector<std::string>{});
     s.str("");
     s << p;
-    REQUIRE(s.str() == R"(  git {OPTIONS}
+    REQUIRE(s.str() == R"(  git [COMMAND] {OPTIONS}
 
     git-like parser
 


### PR DESCRIPTION
I've improved help output for commands. Commands have description and epilogue just as ArgumentParser. Help exception can be handled at top-level command since `stream << argumentParser` will print help page for selected command.

There are also `showCommandChildren` and `showCommandFullHelp` modes (not sure about the names, any ideas?). They might be useful when your app has a few commands and default mode will print not informative help message.

In these modes `Subparser::Parse` will throw `Help` exception to get descriptions from subparser. I will change it to some `InternalHelp` in next PR about validation and error handling in commands.