### PR TITLE
Add more help parameters

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -114,37 +114,48 @@ namespace args
 
         std::istringstream stream(in);
         std::vector<std::string> output;
-        std::ostringstream line;
-        std::string::size_type linesize = 0;
+        std::string line;
+        bool empty = true;
+
+        for (char c : in)
+        {
+            if (!isspace(c))
+            {
+                break;
+            }
+            line += c;
+        }
+
         while (stream)
         {
             std::string item;
             stream >> item;
             auto itemsize = Glyphs(item);
-            if ((linesize + 1 + itemsize) > currentwidth)
+            if ((line.length() + 1 + itemsize) > currentwidth)
             {
-                if (linesize > 0)
+                if (!empty)
                 {
-                    output.push_back(line.str());
-                    line.str(std::string());
-                    linesize = 0;
+                    output.push_back(line);
+                    line.clear();
+                    empty = true;
                     currentwidth = width;
                 }
             }
             if (itemsize > 0)
             {
-                if (linesize)
+                if (!empty)
                 {
-                    ++linesize;
-                    line << " ";
+                    line += ' ';
                 }
-                line << item;
-                linesize += itemsize;
+
+                line += item;
+                empty = false;
             }
         }
-        if (linesize > 0)
+
+        if (!empty)
         {
-            output.push_back(line.str());
+            output.push_back(line);
         }
         return output;
     }

--- a/args.hxx
+++ b/args.hxx
@@ -867,25 +867,22 @@ namespace args
                 std::string flags;
                 const auto flagStrings = matcher.GetFlagStrings();
                 const bool useValueNameOnce = flagStrings.size() == 1 ? false : params.useValueNameOnce;
-                for (const auto &flag : flagStrings)
+                for (auto it = flagStrings.begin(); it != flagStrings.end(); ++it)
                 {
-                    if (!flags.empty())
+                    auto &flag = *it;
+                    if (it != flagStrings.begin())
                     {
                         flags += ", ";
                     }
 
                     flags += flag.isShort ? params.shortPrefix : params.longPrefix;
                     flags += flag.str();
-                    if (!postfix.empty() && !useValueNameOnce)
+
+                    if (!postfix.empty() && (!useValueNameOnce || it + 1 == flagStrings.end()))
                     {
                         flags += flag.isShort ? params.shortSeparator : params.longSeparator;
                         flags += "[" + postfix + "]";
                     }
-                }
-
-                if (!postfix.empty() && useValueNameOnce)
-                {
-                    flags += " [" + postfix + "]";
                 }
 
                 std::get<0>(description) = std::move(flags);

--- a/test.cxx
+++ b/test.cxx
@@ -964,6 +964,78 @@ TEST_CASE("Matcher validation works as expected", "[args]")
     REQUIRE_THROWS_AS(args::ValueFlag<int>(parser, "", "", {}), args::UsageError);
 }
 
+TEST_CASE("HelpParams work as expected", "[args]")
+{
+    args::ArgumentParser p("parser");
+    args::ValueFlag<std::string> f(p, "name", "description", {'f', "foo"});
+    args::ValueFlag<std::string> g(p, "name", "description", {'g'});
+    p.Prog("prog");
+
+    REQUIRE(p.Help() == R"(  prog {OPTIONS}
+
+    parser
+
+  OPTIONS:
+
+      -f[name], --foo=[name]            description
+      -g[name]                          description
+
+)");
+
+    p.helpParams.usageString = "usage: ";
+    p.helpParams.optionsString = "Options";
+    p.helpParams.useValueNameOnce = true;
+    REQUIRE(p.Help() == R"(  usage: prog {OPTIONS}
+
+    parser
+
+  Options
+
+      -f, --foo [name]                  description
+      -g[name]                          description
+
+)");
+
+    p.helpParams.showValueName = false;
+    p.helpParams.optionsString = {};
+    REQUIRE(p.Help() == R"(  usage: prog {OPTIONS}
+
+    parser
+
+      -f, --foo                         description
+      -g                                description
+
+)");
+
+    p.helpParams.helpindent = 12;
+    p.helpParams.optionsString = "Options";
+    REQUIRE(p.Help() == R"(  usage: prog {OPTIONS}
+
+    parser
+
+  Options
+
+      -f, --foo
+            description
+      -g    description
+
+)");
+
+    p.helpParams.addNewlineBeforeDescription = true;
+    REQUIRE(p.Help() == R"(  usage: prog {OPTIONS}
+
+    parser
+
+  Options
+
+      -f, --foo
+            description
+      -g
+            description
+
+)");
+}
+
 #undef ARGS_HXX
 #define ARGS_TESTNAMESPACE
 #define ARGS_NOEXCEPT

--- a/test.cxx
+++ b/test.cxx
@@ -993,7 +993,7 @@ TEST_CASE("HelpParams work as expected", "[args]")
 
   Options
 
-      -f, --foo [name]                  description
+      -f, --foo=[name]                  description
       -g[name]                          description
                                           d1
                                           d2

--- a/test.cxx
+++ b/test.cxx
@@ -968,7 +968,7 @@ TEST_CASE("HelpParams work as expected", "[args]")
 {
     args::ArgumentParser p("parser");
     args::ValueFlag<std::string> f(p, "name", "description", {'f', "foo"});
-    args::ValueFlag<std::string> g(p, "name", "description", {'g'});
+    args::ValueFlag<std::string> g(p, "name", "description\n  d1\n  d2", {'g'});
     p.Prog("prog");
 
     REQUIRE(p.Help() == R"(  prog {OPTIONS}
@@ -979,6 +979,8 @@ TEST_CASE("HelpParams work as expected", "[args]")
 
       -f[name], --foo=[name]            description
       -g[name]                          description
+                                          d1
+                                          d2
 
 )");
 
@@ -993,6 +995,8 @@ TEST_CASE("HelpParams work as expected", "[args]")
 
       -f, --foo [name]                  description
       -g[name]                          description
+                                          d1
+                                          d2
 
 )");
 
@@ -1004,6 +1008,8 @@ TEST_CASE("HelpParams work as expected", "[args]")
 
       -f, --foo                         description
       -g                                description
+                                          d1
+                                          d2
 
 )");
 
@@ -1018,6 +1024,8 @@ TEST_CASE("HelpParams work as expected", "[args]")
       -f, --foo
             description
       -g    description
+              d1
+              d2
 
 )");
 
@@ -1032,8 +1040,30 @@ TEST_CASE("HelpParams work as expected", "[args]")
             description
       -g
             description
+              d1
+              d2
 
 )");
+
+    args::ValueFlag<std::string> e(p, "name", "some reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally loooooooooooooooooooooooooooong description", {'e'});
+    REQUIRE(p.Help() == R"(  usage: prog {OPTIONS}
+
+    parser
+
+  Options
+
+      -f, --foo
+            description
+      -g
+            description
+              d1
+              d2
+      -e
+            some reaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaally
+            loooooooooooooooooooooooooooong description
+
+)");
+
 }
 
 #undef ARGS_HXX


### PR DESCRIPTION
`usageStrings` can be used to add prefix to program line, e.g. `usage: `.

`optionsString` allows you to change default `OPTIONS:` string in help output.

`useValueNameOnce` hides multiple value names from description: `-f[FILE], --file=[FILE]` vs `-f, --file=[FILE]`.

`showValueName` allows you to hide value names.

`addNewlineBeforeDescription` adds a newline before flag description.

Wrap now don't trim leading whitespace. Indenting lines in description might be useful.