### PR TITLE
Add examples for commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 #### Note that this library is essentially in maintenance mode.  I haven't had the time to work on it or give it the love that it deserves.  I'm not adding new features, but I will fix bugs.  I will also very gladly accept pull requests.
 
-[![build status](https://travis-ci.org/Taywee/args.svg?branch=master)](https://travis-ci.org/Taywee/args)
-[![Build status](https://ci.appveyor.com/api/projects/status/nlnlmpttdjlndyc2?svg=true)](https://ci.appveyor.com/project/Taywee/args)
+[![Cpp Standard](https://img.shields.io/badge/C%2B%2B-11-blue.svg)](https://img.shields.io/badge/C%2B%2B-11-blue.svg)
+[![Travis status](https://travis-ci.org/Taywee/args.svg?branch=master)](https://travis-ci.org/Taywee/args)
+[![AppVeyor status](https://ci.appveyor.com/api/projects/status/nlnlmpttdjlndyc2?svg=true)](https://ci.appveyor.com/project/Taywee/args)
 [![Coverage Status](https://coveralls.io/repos/github/Taywee/args/badge.svg?branch=master)](https://coveralls.io/github/Taywee/args?branch=master)
+[![Read the Docs](https://img.shields.io/readthedocs/pip.svg)](https://taywee.github.io/args)
 
 A simple, small, flexible, single-header C++11 argument parsing library, in
 fewer than 2K lines of code.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 #### Note that this library is essentially in maintenance mode.  I haven't had the time to work on it or give it the love that it deserves.  I'm not adding new features, but I will fix bugs.  I will also very gladly accept pull requests.
 
-[![Cpp Standard](https://img.shields.io/badge/C%2B%2B-11-blue.svg)](https://img.shields.io/badge/C%2B%2B-11-blue.svg)
+[![Cpp Standard](https://img.shields.io/badge/C%2B%2B-11-blue.svg)](https://en.wikipedia.org/wiki/C%2B%2B11)
 [![Travis status](https://travis-ci.org/Taywee/args.svg?branch=master)](https://travis-ci.org/Taywee/args)
 [![AppVeyor status](https://ci.appveyor.com/api/projects/status/nlnlmpttdjlndyc2?svg=true)](https://ci.appveyor.com/project/Taywee/args)
 [![Coverage Status](https://coveralls.io/repos/github/Taywee/args/badge.svg?branch=master)](https://coveralls.io/github/Taywee/args?branch=master)

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ It:
 * Lets you decide not to allow separate-argument value flags or joined ones
   (like disallowing `--foo bar`, requiring `--foo=bar`, or the inverse, or the
   same for short options).
-* Allows you to create subparsers, reusing arguments for multiple commands and
-  refactoring your command logic to function or lambda
+* Allows you to create subparsers, to reuse arguments for multiple commands and
+  to refactor your command's logic to a function or lambda
 * Allows one value flag to take a specific number of values (like `--foo first
   second`, where --foo slurps both arguments).
 * Allows you to have value flags only optionally accept values


### PR DESCRIPTION
I added two examples for new commands feature: the first one has everything in one function and the second one uses lambdas and functions.