### PR TITLE
Add default values and choices to help output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ target_link_libraries(argstest args)
 set_property(TARGET argstest PROPERTY CXX_STANDARD 11)
 
 if (MSVC)
-    target_compile_options(argstest PRIVATE /W4 /WX)
+    target_compile_options(argstest PRIVATE /W4 /WX /bigobj)
 else ()
     target_compile_options(argstest PRIVATE -Wall -Wextra -Werror -pedantic -Wshadow -Wunused-parameter)
 endif ()

--- a/args.hxx
+++ b/args.hxx
@@ -575,6 +575,30 @@ namespace args
          */
         std::string proglineCommand = "COMMAND";
 
+        /** The prefix for progline value
+         */
+        std::string proglineValueOpen = " <";
+
+        /** The postfix for progline value
+         */
+        std::string proglineValueClose = ">";
+
+        /** The prefix for progline required argument
+         */
+        std::string proglineRequiredOpen = "";
+
+        /** The postfix for progline required argument
+         */
+        std::string proglineRequiredClose = "";
+
+        /** The prefix for progline non-required argument
+         */
+        std::string proglineNonrequiredOpen = "[";
+
+        /** The postfix for progline non-required argument
+         */
+        std::string proglineNonrequiredClose = "]";
+
         /** Show flags in program line
          */
         bool proglineShowFlags = false;
@@ -602,6 +626,15 @@ namespace args
         /** Add newline before flag description
          */
         bool addNewlineBeforeDescription = false;
+
+        /** The prefix for option value
+         */
+        std::string valueOpen = "[";
+
+        /** The postfix for option value
+         */
+        std::string valueClose = "]";
+
     };
 
     /** Base class for all match types
@@ -854,10 +887,11 @@ namespace args
                 std::string res = flag.str(params.shortPrefix, params.longPrefix);
                 if (!postfix.empty())
                 {
-                    res += " <" + postfix + ">";
+                    res += params.proglineValueOpen + postfix + params.proglineValueClose;
                 }
 
-                return { IsRequired() ? res : "[" + res + "]" };
+                return { IsRequired() ? params.proglineRequiredOpen + res + params.proglineRequiredClose
+                                      : params.proglineNonrequiredOpen + res + params.proglineNonrequiredClose };
             }
 
             virtual std::vector<std::tuple<std::string, std::string, unsigned>> GetDescription(const HelpParams &params, const unsigned indentLevel) const override
@@ -881,7 +915,7 @@ namespace args
                     if (!postfix.empty() && (!useValueNameOnce || it + 1 == flagStrings.end()))
                     {
                         flags += flag.isShort ? params.shortSeparator : params.longSeparator;
-                        flags += "[" + postfix + "]";
+                        flags += params.valueOpen + postfix + params.valueClose;
                     }
                 }
 
@@ -981,9 +1015,10 @@ namespace args
                 return true;
             }
 
-            virtual std::vector<std::string> GetProgramLine(const HelpParams &) const override
+            virtual std::vector<std::string> GetProgramLine(const HelpParams &params) const override
             {
-                return { IsRequired() ? Name() : "[" + Name() + ']' };
+                return { IsRequired() ? params.proglineRequiredOpen + Name() + params.proglineRequiredClose
+                                      : params.proglineNonrequiredOpen + Name() + params.proglineNonrequiredClose };
             }
 
             virtual void Validate(const std::string &, const std::string &) const override

--- a/args.hxx
+++ b/args.hxx
@@ -2786,7 +2786,7 @@ namespace args
             T value;
             T defaultValue;
 
-            virtual std::string GetDefaultString(const HelpParams&) const
+            virtual std::string GetDefaultString(const HelpParams&) const override
             {
                 return detail::ToString(defaultValue);
             }

--- a/test.cxx
+++ b/test.cxx
@@ -1088,6 +1088,68 @@ TEST_CASE("ActionFlag works as expected", "[args]")
     REQUIRE_THROWS_AS(p.ParseArgs(std::vector<std::string>{"-v"}), std::runtime_error);
 }
 
+TEST_CASE("Default values work as expected", "[args]")
+{
+    args::ArgumentParser p("parser");
+    args::ValueFlag<std::string> f(p, "name", "description", {'f', "foo"}, "abc");
+    args::MapFlag<std::string, int> b(p, "name", "description", {'b', "bar"}, {{"a", 1}, {"b", 2}, {"c", 3}});
+    p.Prog("prog");
+    REQUIRE(p.Help() == R"(  prog {OPTIONS}
+
+    parser
+
+  OPTIONS:
+
+      -f[name], --foo=[name]            description
+      -b[name], --bar=[name]            description
+
+)");
+
+    p.helpParams.addDefault = true;
+    p.helpParams.addChoices = true;
+
+    REQUIRE(p.Help() == R"(  prog {OPTIONS}
+
+    parser
+
+  OPTIONS:
+
+      -f[name], --foo=[name]            description
+                                        Default: abc
+      -b[name], --bar=[name]            description
+                                        One of: a, b, c
+
+)");
+
+    f.HelpDefault("123");
+    b.HelpChoices("1, 2, 3");
+    REQUIRE(p.Help() == R"(  prog {OPTIONS}
+
+    parser
+
+  OPTIONS:
+
+      -f[name], --foo=[name]            description
+                                        Default: 123
+      -b[name], --bar=[name]            description
+                                        One of: 1, 2, 3
+
+)");
+
+    f.HelpDefault({});
+    b.HelpChoices({});
+    REQUIRE(p.Help() == R"(  prog {OPTIONS}
+
+    parser
+
+  OPTIONS:
+
+      -f[name], --foo=[name]            description
+      -b[name], --bar=[name]            description
+
+)");
+}
+
 #undef ARGS_HXX
 #define ARGS_TESTNAMESPACE
 #define ARGS_NOEXCEPT


### PR DESCRIPTION
Fixes #6, #25.

Set `HelpParams::addDefault` and `HelpParams::addChoices` to enable auto-generated default/choices strings globally. Use `NamedBase::HelpDefault(string)` and `NamedBase::HelpChoices(string)` to enable/disable it.
