### PR TITLE
ActionFlag

### DIFF
--- a/test.cxx
+++ b/test.cxx
@@ -1066,6 +1066,25 @@ TEST_CASE("HelpParams work as expected", "[args]")
 
 }
 
+TEST_CASE("ActionFlag works as expected", "[args]")
+{
+    args::ArgumentParser p("parser");
+    std::string s;
+
+    args::ActionFlag action0(p, "name", "description", {'x'}, [&]() { s = "flag"; });
+    args::ActionFlag action1(p, "name", "description", {'y'}, [&](const std::string &arg) { s = arg; });
+    args::ActionFlag actionN(p, "name", "description", {'z'}, 2, [&](const std::vector<std::string> &arg) { s = arg[0] + arg[1]; });
+
+    p.ParseArgs(std::vector<std::string>{"-x"});
+    REQUIRE(s == "flag");
+
+    p.ParseArgs(std::vector<std::string>{"-y", "a"});
+    REQUIRE(s == "a");
+
+    p.ParseArgs(std::vector<std::string>{"-z", "a", "b"});
+    REQUIRE(s == "ab");
+}
+
 #undef ARGS_HXX
 #define ARGS_TESTNAMESPACE
 #define ARGS_NOEXCEPT

--- a/test.cxx
+++ b/test.cxx
@@ -1074,6 +1074,7 @@ TEST_CASE("ActionFlag works as expected", "[args]")
     args::ActionFlag action0(p, "name", "description", {'x'}, [&]() { s = "flag"; });
     args::ActionFlag action1(p, "name", "description", {'y'}, [&](const std::string &arg) { s = arg; });
     args::ActionFlag actionN(p, "name", "description", {'z'}, 2, [&](const std::vector<std::string> &arg) { s = arg[0] + arg[1]; });
+    args::ActionFlag actionThrow(p, "name", "description", {'v'}, [&]() { throw std::runtime_error(""); });
 
     p.ParseArgs(std::vector<std::string>{"-x"});
     REQUIRE(s == "flag");
@@ -1083,6 +1084,8 @@ TEST_CASE("ActionFlag works as expected", "[args]")
 
     p.ParseArgs(std::vector<std::string>{"-z", "a", "b"});
     REQUIRE(s == "ab");
+
+    REQUIRE_THROWS_AS(p.ParseArgs(std::vector<std::string>{"-v"}), std::runtime_error);
 }
 
 #undef ARGS_HXX


### PR DESCRIPTION
Fixes #27. Adds simple ActionFlag that calls a function.

```c++
args::ActionFlag version(parser, "version", "show version", {'v', "version"}, []() { throw Version(); });
```

You can also define "value-accepting" ActionFlag by changing function argument type.
```c++
args::ActionFlag noArg(..., []() { });
args::ActionFlag oneArg(..., [](const std::string &) { });
args::ActionFlag nArgs(..., args::Nargs(2), [](const std::vector<std::string> &) { });
```
