### PR TITLE
Fix usage line wrapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,8 @@ doc/man:
 	doxygen Doxyfile
 	bzip2 doc/man/man3/*.3
 
-runtests: test
-	./test
+runtests: ${EXECUTABLE}
+	./${EXECUTABLE}
 
 %.o: %.cxx
 	$(CXX) $< -o $@ $(CFLAGS)


### PR DESCRIPTION
New `proglineShowFlags=true` feature doesn't look nice with wrapping:

```bash
  myprog [--foo <foo>] [--bar <bar>] [--baz
    <baz>]
```

I fixed this by wrapping usage line by "tokens".
```bash
  myprog [--foo <foo>] [--bar <bar>]
     [--baz <baz>]
```