### PR TITLE
Add Options::HiddenFromUsage and Options::HiddenFromDescription

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -514,17 +514,25 @@ namespace args
          */
         Required = 0x02,
 
-        /** Flag is excluded from help output.
+        /** Flag is excluded from usage line.
          */
-        Hidden = 0x04,
+        HiddenFromUsage = 0x04,
+
+        /** Flag is excluded from options help.
+         */
+        HiddenFromDescription = 0x08,
 
         /** Flag is global and can be used in any subcommand.
          */
-        Global = 0x08,
+        Global = 0x10,
 
         /** Flag stops a parser.
          */
-        KickOut = 0x10,
+        KickOut = 0x20,
+
+        /** Flag is excluded from options help and usage line
+         */
+        Hidden = HiddenFromUsage | HiddenFromDescription,
     };
 
     inline Options operator | (Options lhs, Options rhs)
@@ -1350,7 +1358,7 @@ namespace args
 
                 for (Base *child: Children())
                 {
-                    if ((child->GetOptions() & Options::Hidden) != Options::None)
+                    if ((child->GetOptions() & Options::HiddenFromDescription) != Options::None)
                     {
                         continue;
                     }
@@ -1371,7 +1379,7 @@ namespace args
                 std::vector <std::string> names;
                 for (Base *child: Children())
                 {
-                    if ((child->GetOptions() & Options::Hidden) != Options::None)
+                    if ((child->GetOptions() & Options::HiddenFromUsage) != Options::None)
                     {
                         continue;
                     }
@@ -1900,7 +1908,7 @@ namespace args
 
                 for (Base *child: Children())
                 {
-                    if ((child->GetOptions() & Options::Hidden) != Options::None)
+                    if ((child->GetOptions() & Options::HiddenFromDescription) != Options::None)
                     {
                         continue;
                     }

--- a/test.cxx
+++ b/test.cxx
@@ -593,8 +593,8 @@ TEST_CASE("Required flags work as expected", "[args]")
 TEST_CASE("Hidden options are excluded from help", "[args]")
 {
     args::ArgumentParser parser1("");
-    args::ValueFlag<int> foo(parser1, "foo", "foo", {'f', "foo"}, args::Options::Hidden);
-    args::ValueFlag<int> bar(parser1, "bar", "bar", {'b'});
+    args::ValueFlag<int> foo(parser1, "foo", "foo", {'f', "foo"}, args::Options::HiddenFromDescription);
+    args::ValueFlag<int> bar(parser1, "bar", "bar", {'b'}, args::Options::HiddenFromUsage);
     args::Group group(parser1, "group");
     args::ValueFlag<int> foo1(group, "foo", "foo", {'f', "foo"}, args::Options::Hidden);
     args::ValueFlag<int> bar2(group, "bar", "bar", {'b'});
@@ -604,6 +604,10 @@ TEST_CASE("Hidden options are excluded from help", "[args]")
     REQUIRE(std::get<0>(desc[0]) == "-b[bar]");
     REQUIRE(std::get<0>(desc[1]) == "group");
     REQUIRE(std::get<0>(desc[2]) == "-b[bar]");
+
+    parser1.helpParams.proglineShowFlags = true;
+    parser1.helpParams.proglinePreferShortFlags = true;
+    REQUIRE((parser1.GetProgramLine(parser1.helpParams) == std::vector<std::string>{"[-f <foo>]", "[-b <bar>]"}));
 }
 
 TEST_CASE("Implicit values work as expected", "[args]")


### PR DESCRIPTION
Split `Options::Hidden` into `Options::HiddenFromUsage` and `Options::HiddenFromDescription`.

The main use case for `HiddenFromDescription` is hiding positional options. `HiddenFromUsage` could be used to leave only the most important options in usage line, otherwise it would be too long.