### PR TITLE
Buck build support

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -1,0 +1,7 @@
+[project]
+  ignore = .git
+
+[cxx]
+  should_remap_host_platform = true
+  untracked_headers = error
+  untracked_headers_whitelist = /usr/include/.*, /usr/lib/gcc/.*

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ Makefile
 *-prefix
 gitlike
 /pages/
+
+# Buck
+/buck-out/
+/.buckd/
+.buckconfig.local

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,35 @@
+prebuilt_cxx_library(
+  name = 'args', 
+  header_namespace = '', 
+  header_only = True, 
+  exported_headers = [
+    'args.hxx', 
+  ], 
+  visibility = [
+    'PUBLIC', 
+  ],
+)
+
+cxx_binary(
+  name = 'test', 
+  header_namespace = '', 
+  headers = [
+    'catch.hpp', 
+  ], 
+  srcs = [
+    'test.cxx', 
+  ], 
+  deps = [
+    ':args', 
+  ], 
+)
+
+cxx_binary(
+  name = 'gitlike', 
+  srcs = [
+    'gitlike.cxx', 
+  ], 
+  deps = [
+    ':args', 
+  ], 
+)

--- a/BUCK
+++ b/BUCK
@@ -20,16 +20,6 @@ cxx_binary(
     'test.cxx', 
   ], 
   deps = [
-    ':args', 
-  ], 
-)
-
-cxx_binary(
-  name = 'gitlike', 
-  srcs = [
-    'gitlike.cxx', 
-  ], 
-  deps = [
-    ':args', 
+    '//:args', 
   ], 
 )

--- a/examples/BUCK
+++ b/examples/BUCK
@@ -1,0 +1,19 @@
+cxx_binary(
+  name = 'gitlike', 
+  srcs = [
+    'gitlike.cxx', 
+  ], 
+  deps = [
+    '//:args', 
+  ], 
+)
+
+cxx_binary(
+  name = 'completion', 
+  srcs = [
+    'completion.cxx', 
+  ], 
+  deps = [
+    '//:args', 
+  ], 
+)

--- a/test/BUCK
+++ b/test/BUCK
@@ -1,0 +1,29 @@
+cxx_binary(
+  name = 'multiple-inclusion-1', 
+  srcs = [
+    'multiple_inclusion_1.cxx', 
+  ], 
+  deps = [
+    '//:args', 
+  ], 
+)
+
+cxx_binary(
+  name = 'multiple-inclusion-2', 
+  srcs = [
+    'multiple_inclusion_2.cxx', 
+  ], 
+  deps = [
+    '//:args', 
+  ], 
+)
+
+cxx_binary(
+  name = 'windows-h', 
+  srcs = [
+    'windows_h.cxx', 
+  ], 
+  deps = [
+    '//:args', 
+  ], 
+)


### PR DESCRIPTION
Hello 😄! 

This PR adds support for the [Buck](https://buckbuild.com) build system. Whilst this library is header-only, the Buck file serves as instructions for integrating the headers into other libraries. I also ported the tests + examples. The existing Make build is left unchanged. 

https://github.com/LoopPerfect/buckaroo-wishlist/issues/85