### PR TITLE
Check istringstream state in ValueParser

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -3256,9 +3256,14 @@ namespace args
         operator ()(const std::string &name, const std::string &value, T &destination)
         {
             std::istringstream ss(value);
-            ss >> destination >> std::ws;
+            bool failed = !(ss >> destination);
 
-            if (ss.rdbuf()->in_avail() > 0)
+            if (!failed)
+            {
+                ss >> std::ws;
+            }
+
+            if (ss.rdbuf()->in_avail() > 0 || failed)
             {
 #ifdef ARGS_NOEXCEPT
                 (void)name;

--- a/test.cxx
+++ b/test.cxx
@@ -1173,6 +1173,8 @@ TEST_CASE("ValueParser works as expected", "[args]")
     args::ValueFlag<std::string> f(p, "name", "description", {'f'});
     args::ValueFlag<StringAssignable> b(p, "name", "description", {'b'});
     args::ValueFlag<int> i(p, "name", "description", {'i'});
+    args::ValueFlag<int> d(p, "name", "description", {'d'});
+    args::PositionalList<double> ds(p, "name", "description");
 
     REQUIRE_NOTHROW(p.ParseArgs(std::vector<std::string>{"-f", "a b"}));
     REQUIRE(args::get(f) == "a b");
@@ -1185,6 +1187,11 @@ TEST_CASE("ValueParser works as expected", "[args]")
 
     REQUIRE_NOTHROW(p.ParseArgs(std::vector<std::string>{"-i", " 12"}));
     REQUIRE(args::get(i) == 12);
+
+    REQUIRE_THROWS_AS(p.ParseArgs(std::vector<std::string>{"-i", "a"}), args::ParseError);
+    REQUIRE_THROWS_AS(p.ParseArgs(std::vector<std::string>{"-d", "b"}), args::ParseError);
+    REQUIRE_THROWS_AS(p.ParseArgs(std::vector<std::string>{"c"}), args::ParseError);
+    REQUIRE_THROWS_AS(p.ParseArgs(std::vector<std::string>{"s"}), args::ParseError);
 }
 
 TEST_CASE("ActionFlag works as expected", "[args]")


### PR DESCRIPTION
Fixes #75 

BTW, @Taywee, is this `std::ws` part in ValueParser really necessary? It seems strange to have command line like `-i '42 '`.