### PR TITLE
Fix static code analysis warnings in Visual Studio 2019

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -227,7 +227,7 @@ namespace args
         std::istringstream stream(in);
         std::string::size_type indent = 0;
 
-        for (char c : in)
+        for (unsigned char c : in)
         {
             if (!isspace(c))
             {
@@ -463,7 +463,7 @@ namespace args
             Matcher(std::initializer_list<EitherFlag> in) :
                 Matcher(EitherFlag::GetShort(in), EitherFlag::GetLong(in)) {}
 
-            Matcher(Matcher &&other) : shortFlags(std::move(other.shortFlags)), longFlags(std::move(other.longFlags))
+            Matcher(Matcher &&other) noexcept : shortFlags(std::move(other.shortFlags)), longFlags(std::move(other.longFlags))
             {}
 
             ~Matcher() {}
@@ -2016,7 +2016,7 @@ namespace args
                 if (!ProglinePostfix().empty())
                 {
                     std::string line;
-                    for (char c : ProglinePostfix())
+                    for (unsigned char c : ProglinePostfix())
                     {
                         if (isspace(c))
                         {


### PR DESCRIPTION
Fix the three warnings below. This fixes Issue #88 (noexcept). Not sure if the signed/unsigned char fix is ok for platforms other than Windows.

Utilities\DxFileUtility\DxFileUtility\args.hxx (232, 0)
Utilities\DxFileUtility\DxFileUtility\args.hxx(232,0): Warning C6330: 'char' passed as _Param_(1) when 'unsigned char' is required in call to 'isspace'.
Utilities\DxFileUtility\DxFileUtility\args.hxx (466, 0)
Utilities\DxFileUtility\DxFileUtility\args.hxx(466,0): Warning C26439: This kind of function may not throw. Declare it 'noexcept' (f.6).
Utilities\DxFileUtility\DxFileUtility\args.hxx (2021, 0)
Utilities\DxFileUtility\DxFileUtility\args.hxx(2021,0): Warning C6330: 'char' passed as _Param_(1) when 'unsigned char' is required in call to 'isspace'.