### PR TITLE
Export taywee::args

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,12 @@ if (ARGS_BUILD_UNITTESTS)
     add_test(NAME "test-multiple-inclusion" COMMAND argstest-multiple-inclusion)
 endif()
 
+add_library(taywee::args ALIAS args)
+export(
+    TARGETS args
+    NAMESPACE taywee::
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/args-targets.cmake")
+
 set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
 set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
 set(CPACK_PACKAGE_VENDOR "${PROJECT_NAME} developers")


### PR DESCRIPTION
Most of downstream distribution systems prefer using ports rather than fetching anything during the build. FTXUI depends on args via FetchContent. CMake 3.24 support FIND_PACKAGE_ARGS to allow installed packages to override fetch_content.

My problem is that `taywee::args` is only exported when installed, but only as "args" when used
as a subproject.

This patch exports `taywee::args` so that the same name can be used in both cases.

Bug:https://github.com/ArthurSonzogni/json-tui/issues/32