### PR TITLE
Reject negative input and partial parsing for unsigned argument types

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -3323,32 +3323,54 @@ namespace args
      */
     struct ValueReader
     {
+      private:
+        template <typename T>
+        static typename std::enable_if<std::is_integral<T>::value && std::is_unsigned<T>::value, bool>::type
+        HasUnsignedNegativeSign(const std::string &value)
+        {
+            const auto firstNonSpace = std::find_if_not(value.begin(), value.end(), [](char c)
+            {
+                return std::isspace(static_cast<unsigned char>(c)) != 0;
+            });
+
+            return firstNonSpace != value.end() && *firstNonSpace == '-';
+        }
+
+        template <typename T>
+        static typename std::enable_if<!std::is_integral<T>::value || !std::is_unsigned<T>::value, bool>::type
+        HasUnsignedNegativeSign(const std::string &)
+        {
+            return false;
+        }
+
+      public:
         template <typename T>
         typename std::enable_if<!std::is_assignable<T, std::string>::value, bool>::type
         operator ()(const std::string &name, const std::string &value, T &destination)
         {
-            bool failed = false;
-
-            // Prevent "-1" style inputs from being accepted for unsigned integral destinations.
-            if (std::is_integral<T>::value && std::is_unsigned<T>::value)
-            {
-                const auto firstNonSpace = std::find_if_not(value.begin(), value.end(), [](char c)
-                {
-                    return std::isspace(static_cast<unsigned char>(c)) != 0;
-                });
-
-                if (firstNonSpace != value.end() && *firstNonSpace == '-')
-                {
-                    failed = true;
-                }
-            }
+            bool failed = HasUnsignedNegativeSign<T>(value);
 
             std::istringstream ss(value);
             if (!failed)
             {
                 ss >> destination;
-                ss >> std::ws;
-                failed = ss.fail() || ss.peek() != std::char_traits<char>::eof();
+                if (ss.fail())
+                {
+                    failed = true;
+                }
+                else
+                {
+                    // If we can read a non-whitespace character after parsing, the input had junk.
+                    char extra;
+                    if (ss >> extra)
+                    {
+                        failed = true;
+                    }
+                    else if (!ss.eof())
+                    {
+                        failed = true;
+                    }
+                }
             }
 
             if (failed)

--- a/args.hxx
+++ b/args.hxx
@@ -3327,15 +3327,31 @@ namespace args
         typename std::enable_if<!std::is_assignable<T, std::string>::value, bool>::type
         operator ()(const std::string &name, const std::string &value, T &destination)
         {
-            std::istringstream ss(value);
-            bool failed = !(ss >> destination);
+            bool failed = false;
 
-            if (!failed)
+            // Prevent "-1" style inputs from being accepted for unsigned integral destinations.
+            if (std::is_integral<T>::value && std::is_unsigned<T>::value)
             {
-                ss >> std::ws;
+                const auto firstNonSpace = std::find_if_not(value.begin(), value.end(), [](char c)
+                {
+                    return std::isspace(static_cast<unsigned char>(c)) != 0;
+                });
+
+                if (firstNonSpace != value.end() && *firstNonSpace == '-')
+                {
+                    failed = true;
+                }
             }
 
-            if (ss.rdbuf()->in_avail() > 0 || failed)
+            std::istringstream ss(value);
+            if (!failed)
+            {
+                ss >> destination;
+                ss >> std::ws;
+                failed = ss.fail() || ss.peek() != std::char_traits<char>::eof();
+            }
+
+            if (failed)
             {
 #ifdef ARGS_NOEXCEPT
                 (void)name;

--- a/test.cxx
+++ b/test.cxx
@@ -129,6 +129,16 @@ TEST_CASE("Invalid argument parsing throws parsing exceptions", "[args]")
     REQUIRE_THROWS_AS(parser.ParseArgs(std::vector<std::string>{"--foo", "7e4"}), args::ParseError);
 }
 
+TEST_CASE("Negative values are rejected for unsigned flags", "[args]")
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::ValueFlag<unsigned int> uid(parser, "UID", "numeric id", {'u', "uid"});
+
+    REQUIRE_THROWS_AS(parser.ParseArgs(std::vector<std::string>{"--uid", "-1"}), args::ParseError);
+    REQUIRE_THROWS_AS(parser.ParseArgs(std::vector<std::string>{"--uid=-1"}), args::ParseError);
+    REQUIRE_THROWS_AS(parser.ParseArgs(std::vector<std::string>{"--uid", "123abc"}), args::ParseError);
+}
+
 TEST_CASE("Argument flag lists work as expected", "[args]")
 {
     args::ArgumentParser parser("This is a test program.", "This goes after the options.");
@@ -1422,6 +1432,21 @@ TEST_CASE("Noexcept mode works as expected", "[args]")
     REQUIRE(parser.GetError() == argstest::Error::Map);
     parser.ParseArgs(std::vector<std::string>{"--mf", "yellow"});
     REQUIRE(parser.GetError() == argstest::Error::None);
+}
+
+TEST_CASE("Negative values are rejected for unsigned flags in noexcept mode", "[args]")
+{
+    argstest::ArgumentParser parser("Test command");
+    argstest::ValueFlag<unsigned int> uid(parser, "UID", "numeric id", {'u', "uid"});
+
+    parser.ParseArgs(std::vector<std::string>{"--uid", "-1"});
+    REQUIRE(parser.GetError() == argstest::Error::Parse);
+
+    parser.ParseArgs(std::vector<std::string>{"--uid=-1"});
+    REQUIRE(parser.GetError() == argstest::Error::Parse);
+
+    parser.ParseArgs(std::vector<std::string>{"--uid", "123abc"});
+    REQUIRE(parser.GetError() == argstest::Error::Parse);
 }
 
 TEST_CASE("Required flags work as expected in noexcept mode", "[args]")


### PR DESCRIPTION
This patch fixes a parsing flaw in ValueReader where invalid numeric input could be silently accepted.

**Issues addressed:**

1. Negative values for unsigned types:
   Inputs such as "-1" were previously accepted and converted via
   wraparound (e.g., to UINT_MAX), which can bypass validation logic
   in downstream applications.

2. Partial numeric parsing:
   Inputs like "123abc" were partially parsed as 123 and accepted,
   ignoring trailing invalid characters.

**Fix:**
- Reject negative values for unsigned integral destinations
- Require full-string consumption during numeric parsing