### PR TITLE
Fix numeric parsing in CompletionFlag to reject invalid values

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -1258,7 +1258,56 @@ namespace args
             virtual void ParseValue(const std::vector<std::string> &value_) override
             {
                 syntax = value_.at(0);
-                std::istringstream(value_.at(1)) >> cword;
+                const std::string &raw = value_.at(1);
+                bool failed = false;
+
+                const auto firstNonSpace = std::find_if_not(raw.begin(), raw.end(), [](char c)
+                {
+                    return std::isspace(static_cast<unsigned char>(c)) != 0;
+                });
+
+                if (firstNonSpace != raw.end() && *firstNonSpace == '-')
+                {
+                    failed = true;
+                }
+
+                size_t parsed = 0;
+                if (!failed)
+                {
+                    std::istringstream ss(raw);
+                    ss >> parsed;
+                    if (ss.fail())
+                    {
+                        failed = true;
+                    }
+                    else
+                    {
+                        char extra;
+                        if (ss >> extra)
+                        {
+                            failed = true;
+                        }
+                        else if (!ss.eof())
+                        {
+                            failed = true;
+                        }
+                    }
+                }
+
+                if (failed)
+                {
+#ifdef ARGS_NOEXCEPT
+                    error = Error::Parse;
+                    errorMsg = "Argument 'completion' received invalid value type '" + raw + "'";
+#else
+                    std::ostringstream problem;
+                    problem << "Argument 'completion' received invalid value type '" << raw << "'";
+                    throw ParseError(problem.str());
+#endif
+                    return;
+                }
+
+                cword = parsed;
             }
 
             /** Get the completion reply
@@ -2760,6 +2809,16 @@ namespace args
                     if (!readCompletion && completion != nullptr && completion->Matched())
                     {
 #ifdef ARGS_NOEXCEPT
+                        if (completion->GetError() != Error::None)
+                        {
+                            error = completion->GetError();
+                            if (errorMsg.empty())
+                            {
+                                errorMsg = completion->GetErrorMsg();
+                            }
+                            return it;
+                        }
+
                         error = Error::Completion;
 #endif
                         readCompletion = true;
@@ -3360,16 +3419,9 @@ namespace args
                 }
                 else
                 {
-                    // If we can read a non-whitespace character after parsing, the input had junk.
-                    char extra;
-                    if (ss >> extra)
-                    {
-                        failed = true;
-                    }
-                    else if (!ss.eof())
-                    {
-                        failed = true;
-                    }
+                    // Skip trailing whitespace and require full consumption.
+                    ss >> std::ws;
+                    failed = ss.peek() != std::char_traits<char>::eof();
                 }
             }
 

--- a/test.cxx
+++ b/test.cxx
@@ -1370,6 +1370,17 @@ TEST_CASE("Completion works as expected", "[args]")
     REQUIRE_THROWS_WITH(p2.ParseArgs(std::vector<std::string>{"--completion", "bash", "3", "test", "command1", "-f", "-"}), Equals(""));
 }
 
+TEST_CASE("Completion rejects malformed cword values", "[args]")
+{
+    args::ArgumentParser p("parser");
+    args::CompletionFlag c(p, {"completion"});
+    args::Group g(p);
+    args::ValueFlag<std::string> f(g, "name", "description", {'f', "foo"}, "abc");
+
+    REQUIRE_THROWS_AS(p.ParseArgs(std::vector<std::string>{"--completion", "bash", "1x", "test", "-"}), args::ParseError);
+    REQUIRE_THROWS_AS(p.ParseArgs(std::vector<std::string>{"--completion", "bash", "-1", "test", "-"}), args::ParseError);
+}
+
 #undef ARGS_HXX
 #define ARGS_TESTNAMESPACE
 #define ARGS_NOEXCEPT
@@ -1547,4 +1558,18 @@ TEST_CASE("Completion works as expected in noexcept mode", "[args]")
     p.ParseArgs(std::vector<std::string>{"--completion", "bash", "1", "test", "-"});
     REQUIRE(p.GetError() == argstest::Error::Completion);
     REQUIRE(argstest::get(c) == "-f\n-b");
+}
+
+TEST_CASE("Completion rejects malformed cword values in noexcept mode", "[args]")
+{
+    argstest::ArgumentParser p("parser");
+    argstest::CompletionFlag c(p, {"completion"});
+    argstest::Group g(p);
+    argstest::ValueFlag<std::string> f(g, "name", "description", {'f', "foo"}, "abc");
+
+    p.ParseArgs(std::vector<std::string>{"--completion", "bash", "1x", "test", "-"});
+    REQUIRE(p.GetError() == argstest::Error::Parse);
+
+    p.ParseArgs(std::vector<std::string>{"--completion", "bash", "-1", "test", "-"});
+    REQUIRE(p.GetError() == argstest::Error::Parse);
 }


### PR DESCRIPTION
This patch fixes improper numeric parsing in CompletionFlag::ParseValue where invalid inputs were previously accepted due to permissive stream extraction behavior

## Fix

The parsing logic is updated to enforce strict validation:

- Skip leading whitespace
- Parse into size_t
- Reject if:
  - parsing fails
  - extra characters remain after parsing
  - input represents a negative value