### PR TITLE
Workaround for argstest build error on Clang 22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,10 @@ if (ARGS_BUILD_UNITTESTS)
         target_compile_options(argstest PRIVATE -Wall -Wextra -Werror -pedantic -Wshadow -Wunused-parameter)
     endif ()
 
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 22)
+        target_compile_options(argstest PRIVATE -Wno-c2y-extensions)
+    endif ()
+
     add_executable(argstest-multiple-inclusion test/multiple_inclusion_1.cxx test/multiple_inclusion_2.cxx)
 
     target_link_libraries(argstest-multiple-inclusion args)


### PR DESCRIPTION
Ran into this error when packaging the new version for MSYS2 last night.

Adding `-Wno-c2y-extensions` seems to work. This change will only apply the flag to `argstest` when building with Clang 22+

```
C:\Users\Noe\AppData\Local\Programs\MSYS2\clang64\bin\c++.exe  -IC:/Users/Noe/Projects/args -g -std=gnu++11 -fansi-escape-codes -fcolor-diagnostics -Wall -Wextra -Werror -pedantic -Wshadow -Wunused-parameter -MD -MT CMakeFiles/argstest.dir/test.cxx.obj -MF CMakeFiles\argstest.dir\test.cxx.obj.d -o CMakeFiles/argstest.dir/test.cxx.obj -c C:/Users/Noe/Projects/args/test.cxx
C:/Users/Noe/Projects/args/test.cxx:21:1: error: '__COUNTER__' is a C2y extension [-Werror,-Wc2y-extensions]
   21 | TEST_CASE("Help flag throws Help exception", "[args]")
      | ^
C:/Users/Noe/Projects/args/catch.hpp:17695:26: note: expanded from macro 'TEST_CASE'
 17695 | #define TEST_CASE( ... ) INTERNAL_CATCH_TESTCASE( __VA_ARGS__ )
       |                          ^
C:/Users/Noe/Projects/args/catch.hpp:1053:35: note: expanded from macro 'INTERNAL_CATCH_TESTCASE'
 1053 |         INTERNAL_CATCH_TESTCASE2( INTERNAL_CATCH_UNIQUE_NAME( ____C_A_T_C_H____T_E_S_T____ ), __VA_ARGS__ )
      |                                   ^
C:/Users/Noe/Projects/args/catch.hpp:469:85: note: expanded from macro 'INTERNAL_CATCH_UNIQUE_NAME'
  469 | #  define INTERNAL_CATCH_UNIQUE_NAME( name ) INTERNAL_CATCH_UNIQUE_NAME_LINE( name, __COUNTER__ )
      |                                                                                     ^
```

More information: https://github.com/catchorg/Catch2/issues/3076