### PR TITLE
Harden numeric argument parsing with validation and overflow checks

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -51,6 +51,9 @@
 #include <type_traits>
 #include <cstddef>
 #include <cctype>
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
 #include <iostream>
 
 #if defined(_MSC_VER) && _MSC_VER <= 1800
@@ -3404,28 +3407,85 @@ namespace args
 
       public:
         template <typename T>
+        typename std::enable_if<
+            std::is_integral<T>::value &&
+            !std::is_same<T, bool>::value &&
+            !std::is_same<T, char>::value &&
+            !std::is_same<T, signed char>::value &&
+            !std::is_same<T, unsigned char>::value,
+            bool>::type
+        ParseNumericValue(const std::string &value, T &destination)
+        {
+            if (HasUnsignedNegativeSign<T>(value))
+            {
+                return false;
+            }
+
+            errno = 0;
+            const char *begin = value.c_str();
+            char *end = nullptr;
+
+            if (std::is_unsigned<T>::value)
+            {
+                const unsigned long long parsed = std::strtoull(begin, &end, 0);
+                while (end != nullptr && *end != '\0' && std::isspace(static_cast<unsigned char>(*end)))
+                {
+                    ++end;
+                }
+                if (end == begin || *end != '\0' || errno == ERANGE || parsed > static_cast<unsigned long long>(std::numeric_limits<T>::max()))
+                {
+                    return false;
+                }
+
+                destination = static_cast<T>(parsed);
+            }
+            else
+            {
+                const long long parsed = std::strtoll(begin, &end, 0);
+                while (end != nullptr && *end != '\0' && std::isspace(static_cast<unsigned char>(*end)))
+                {
+                    ++end;
+                }
+                if (end == begin || *end != '\0' || errno == ERANGE ||
+                    parsed < static_cast<long long>(std::numeric_limits<T>::min()) ||
+                    parsed > static_cast<long long>(std::numeric_limits<T>::max()))
+                {
+                    return false;
+                }
+
+                destination = static_cast<T>(parsed);
+            }
+
+            return true;
+        }
+
+        template <typename T>
+        typename std::enable_if<
+            !std::is_integral<T>::value ||
+            std::is_same<T, bool>::value ||
+            std::is_same<T, char>::value ||
+            std::is_same<T, signed char>::value ||
+            std::is_same<T, unsigned char>::value,
+            bool>::type
+        ParseNumericValue(const std::string &value, T &destination)
+        {
+            std::istringstream ss(value);
+            ss >> destination;
+            if (ss.fail())
+            {
+                return false;
+            }
+
+            ss >> std::ws;
+            return ss.peek() == std::char_traits<char>::eof();
+        }
+
+        template <typename T>
         typename std::enable_if<!std::is_assignable<T, std::string>::value, bool>::type
         operator ()(const std::string &name, const std::string &value, T &destination)
         {
-            bool failed = HasUnsignedNegativeSign<T>(value);
-
-            std::istringstream ss(value);
-            if (!failed)
-            {
-                ss >> destination;
-                if (ss.fail())
-                {
-                    failed = true;
-                }
-                else
-                {
-                    // Skip trailing whitespace and require full consumption.
-                    ss >> std::ws;
-                    failed = ss.peek() != std::char_traits<char>::eof();
-                }
-            }
-
-            if (failed)
+            const bool success = ParseNumericValue(value, destination);
+            if (!success)
             {
 #ifdef ARGS_NOEXCEPT
                 (void)name;

--- a/test.cxx
+++ b/test.cxx
@@ -139,6 +139,16 @@ TEST_CASE("Negative values are rejected for unsigned flags", "[args]")
     REQUIRE_THROWS_AS(parser.ParseArgs(std::vector<std::string>{"--uid", "123abc"}), args::ParseError);
 }
 
+TEST_CASE("Integer overflow values are rejected", "[args]")
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::ValueFlag<int> foo(parser, "FOO", "test flag", {'f', "foo"});
+    args::ValueFlag<unsigned int> uid(parser, "UID", "numeric id", {'u', "uid"});
+
+    REQUIRE_THROWS_AS(parser.ParseArgs(std::vector<std::string>{"--foo", "2147483648"}), args::ParseError);
+    REQUIRE_THROWS_AS(parser.ParseArgs(std::vector<std::string>{"--uid", "4294967296"}), args::ParseError);
+}
+
 TEST_CASE("Argument flag lists work as expected", "[args]")
 {
     args::ArgumentParser parser("This is a test program.", "This goes after the options.");


### PR DESCRIPTION
This PR strengthens the safety and correctness of numeric argument parsing by replacing stream-based parsing with explicit, validated conversions.

### changes

- Switched integral parsing from std::istringstream to std::strtoll / std::strtoull
- Added explicit overflow and range validation using std::numeric_limits
- Enforced full input consumption
- Rejected negative values for unsigned types before conversion
- Preserved existing behavior for char, bool, and non-integral types
- Allowed trailing whitespace to maintain compatibility with current semantics
- This patch ensures all numeric inputs are:
  - Fully validated
  - Range-checked
  - Deterministically parsed or rejected
