### PR TITLE
Value-initialize v in ParseValue

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -3713,7 +3713,7 @@ namespace args
 
                 for (const std::string &value : values_)
                 {
-                    T v;
+                    T v {};
 #ifdef ARGS_NOEXCEPT
                     if (!reader(name, value, v))
                     {


### PR DESCRIPTION
Minor fix for this build error introduced in 6.4.11.

```
[6/7] Building CXX object CMakeFiles/argstest.dir/test.cxx.obj
FAILED: [code=1] CMakeFiles/argstest.dir/test.cxx.obj
C:\Users\Noe\AppData\Local\Programs\MSYS2\ucrt64\bin\g++.exe  -IC:/Users/Noe/Desktop/mingw-w64-args/src/args-6.4.11 -march=nocona -msahf -mtune=generic -O2 -pipe -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wp,-D__USE_MINGW_ANSI_STDIO=1 -O3 -DNDEBUG -std=gnu++11 -Wall -Wextra -Werror -pedantic -Wshadow -Wunused-parameter -MD -MT CMakeFiles/argstest.dir/test.cxx.obj -MF CMakeFiles\argstest.dir\test.cxx.obj.d -o CMakeFiles/argstest.dir/test.cxx.obj -c C:/Users/Noe/Desktop/mingw-w64-args/src/args-6.4.11/test.cxx
In file included from C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/x86_64-w64-mingw32/bits/c++allocator.h:33,
                 from C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/bits/allocator.h:46,
                 from C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/string:45,
                 from C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/bits/locale_classes.h:42,
                 from C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/bits/ios_base.h:43,
                 from C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/ios:46,
                 from C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/bits/ostream.h:43,
                 from C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/ostream:42,
                 from C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/iostream:43,
                 from C:/Users/Noe/Desktop/mingw-w64-args/src/args-6.4.11/test.cxx:6:
In member function 'void std::__new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = int; _Args = {const int&}; _Tp = int]',
    inlined from 'static void std::allocator_traits<std::allocator<_CharT> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = int; _Args = {const int&}; _Tp = int]' at C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/bits/alloc_traits.h:674:17,
    inlined from 'void std::vector<_Tp, _Alloc>::_M_realloc_insert(iterator, _Args&& ...) [with _Args = {const int&}; _Tp = int; _Alloc = std::allocator<int>]' at C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/bits/vector.tcc:481:26,
    inlined from 'std::vector<_Tp, _Alloc>::iterator std::vector<_Tp, _Alloc>::insert(const_iterator, const value_type&) [with _Tp = int; _Alloc = std::allocator<int>]' at C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/bits/vector.tcc:170:19,
    inlined from 'void argstest::NargsValueFlag<T, List, Reader>::ParseValue(const std::vector<std::__cxx11::basic_string<char> >&) [with T = int; List = argstest::detail::vector; Reader = argstest::ValueReader]' at C:/Users/Noe/Desktop/mingw-w64-args/src/args-6.4.11/args.hxx:3725:34:
C:/Users/Noe/AppData/Local/Programs/MSYS2/ucrt64/include/c++/15.2.0/bits/new_allocator.h:191:11: error: 'v' may be used uninitialized [-Werror=maybe-uninitialized]
  191 |         { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from C:/Users/Noe/Desktop/mingw-w64-args/src/args-6.4.11/test.cxx:1397:
C:/Users/Noe/Desktop/mingw-w64-args/src/args-6.4.11/args.hxx: In member function 'void argstest::NargsValueFlag<T, List, Reader>::ParseValue(const std::vector<std::__cxx11::basic_string<char> >&) [with T = int; List = argstest::detail::vector; Reader = argstest::ValueReader]':
C:/Users/Noe/Desktop/mingw-w64-args/src/args-6.4.11/args.hxx:3716:23: note: 'v' was declared here
 3716 |                     T v;
      |                       ^
cc1plus.exe: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```