### PR TITLE
Validate argv/argc in ParseCLI to prevent UB

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -3183,11 +3183,17 @@ namespace args
              */
             bool ParseCLI(const int argc, const char * const * argv)
             {
-                if (Prog().empty())
+                if (argc > 0 && argv != nullptr && argv[0] != nullptr && Prog().empty())
                 {
                     Prog(argv[0]);
                 }
-                const std::vector<std::string> args(argv + 1, argv + argc);
+
+                std::vector<std::string> args;
+                if (argc > 1 && argv != nullptr)
+                {
+                    args.assign(argv + 1, argv + argc);
+                }
+
                 return ParseArgs(args) == std::end(args);
             }
             

--- a/test/parsecli_zero_argc.cxx
+++ b/test/parsecli_zero_argc.cxx
@@ -1,0 +1,18 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    args::ArgumentParser parser("This is a test program.");
+
+    const bool result = parser.ParseCLI(0, nullptr);
+    test::require(result);
+    return 0;
+}


### PR DESCRIPTION
This patch strengthens input validation in `ArgumentParser::ParseCLI` to safely handle invalid or malformed invocation states such as `argc <= 0` or `argv == nullptr`.

The change ensures that the parser no longer relies on implicit assumptions about argument validity and avoids undefined behavior when those assumptions are violated.

### Fix

- Added validation before accessing `argv[0]`
- Guarded vector construction with checks for `argc > 1` and `argv != nullptr`
- Replaced direct vector initialization with safe conditional assignment
