### PR TITLE
Fix undefined behavior in map-backed parsers on reader failure

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -4015,11 +4015,12 @@ namespace args
             {
                 const std::string &value_ = values_.at(0);
 
-                K key;
+                K key{};
 #ifdef ARGS_NOEXCEPT
                 if (!reader(name, value_, key))
                 {
                     error = Error::Parse;
+                    return;
                 }
 #else
                 reader(name, value_, key);
@@ -4135,16 +4136,17 @@ namespace args
 
             virtual void ParseValue(const std::vector<std::string> &values_) override
             {
-                const std::string &value = values_.at(0);
+                const std::string &value_ = values_.at(0);
 
-                K key;
+                K key{};
 #ifdef ARGS_NOEXCEPT
-                if (!reader(name, value, key))
+                if (!reader(name, value_, key))
                 {
                     error = Error::Parse;
+                    return;
                 }
 #else
-                reader(name, value, key);
+                reader(name, value_, key);
 #endif
                 auto it = map.find(key);
                 if (it == std::end(map))
@@ -4517,11 +4519,12 @@ namespace args
 
             virtual void ParseValue(const std::string &value_) override
             {
-                K key;
+                K key{};
 #ifdef ARGS_NOEXCEPT
                 if (!reader(name, value_, key))
                 {
                     error = Error::Parse;
+                    return;
                 }
 #else
                 reader(name, value_, key);
@@ -4641,11 +4644,12 @@ namespace args
 
             virtual void ParseValue(const std::string &value_) override
             {
-                K key;
+                K key{};
 #ifdef ARGS_NOEXCEPT
                 if (!reader(name, value_, key))
                 {
                     error = Error::Parse;
+                    return;
                 }
 #else
                 reader(name, value_, key);

--- a/test/map_invalid_arg_parse.cxx
+++ b/test/map_invalid_arg_parse.cxx
@@ -1,0 +1,41 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    {
+        args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+        args::MapFlag<int, int> map(parser, "MAP", "map", {'m', "map"}, {{1, 1}, {2, 2}});
+        test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"--map", "abc"}); });
+        (void)map;
+    }
+
+    {
+        args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+        args::MapFlagList<int, int> maplist(parser, "MAPLIST", "maplist", {'l', "maplist"}, {{1, 1}, {2, 2}});
+        test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"--maplist", "abc"}); });
+        (void)maplist;
+    }
+
+    {
+        args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+        args::MapPositional<int, int, args::ValueReader, std::map> mappos(parser, "MAPPOS", "mappos", {{1, 1}, {2, 2}});
+        test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"abc"}); });
+        (void)mappos;
+    }
+
+    {
+        args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+        args::MapPositionalList<int, int, std::vector, args::ValueReader, std::map> mapposlist(parser, "MAPPOSLIST", "mapposlist", {{1, 1}, {2, 2}});
+        test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"abc"}); });
+        (void)mapposlist;
+    }
+    return 0;
+}

--- a/test/noexcept_map_invalid_arg_parse.cxx
+++ b/test/noexcept_map_invalid_arg_parse.cxx
@@ -1,0 +1,46 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#define ARGS_NOEXCEPT
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    {
+        args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+        args::MapFlag<int, int> map(parser, "MAP", "map", {'m', "map"}, {{1, 1}, {2, 2}});
+        parser.ParseArgs(std::vector<std::string>{"--map", "abc"});
+        test::require(parser.GetError() == args::Error::Parse);
+        (void)map;
+    }
+
+    {
+        args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+        args::MapFlagList<int, int> maplist(parser, "MAPLIST", "maplist", {'l', "maplist"}, {{1, 1}, {2, 2}});
+        parser.ParseArgs(std::vector<std::string>{"--maplist", "abc"});
+        test::require(parser.GetError() == args::Error::Parse);
+        (void)maplist;
+    }
+
+    {
+        args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+        args::MapPositional<int, int, args::ValueReader, std::map> mappos(parser, "MAPPOS", "mappos", {{1, 1}, {2, 2}});
+        parser.ParseArgs(std::vector<std::string>{"abc"});
+        test::require(parser.GetError() == args::Error::Parse);
+        (void)mappos;
+    }
+
+    {
+        args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+        args::MapPositionalList<int, int, std::vector, args::ValueReader, std::map> mapposlist(parser, "MAPPOSLIST", "mapposlist", {{1, 1}, {2, 2}});
+        parser.ParseArgs(std::vector<std::string>{"abc"});
+        test::require(parser.GetError() == args::Error::Parse);
+        (void)mapposlist;
+    }
+    return 0;
+}


### PR DESCRIPTION
Fixes an undefined behavior issue in map-backed argument parsers when used in ARGS_NOEXCEPT mode.

### Problem

Map-backed parsers (MapFlag, MapFlagList, MapPositional, MapPositionalList) invoke a reader to parse input into a key:

    K key;
    reader(name, value, key);

If parsing fails in ARGS_NOEXCEPT mode, the key remains uninitialized, but execution continues:

    map.find(key);

This results in undefined behavior due to use of an uninitialized variable.

### Fix

- Initialize key (`K key{}`)
- Immediately return on reader failure
- Prevent use of invalid/uninitialized key

### Testing

- Added regression tests covering invalid parsing cases
- Verified both noexcept and throwing configurations