### PR TITLE
enforce completion index validation in ARGS_NOEXCEPT mode

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2829,6 +2829,8 @@ namespace args
                         {
 #ifndef ARGS_NOEXCEPT
                             throw Completion("");
+#else
+                            return end;
 #endif
                         }
 

--- a/test/completion_bad_cword.cxx
+++ b/test/completion_bad_cword.cxx
@@ -17,5 +17,6 @@ int main()
 
     test::require_throws_as<args::ParseError>([&] { p.ParseArgs(std::vector<std::string>{"--completion", "bash", "1x", "test", "-"}); });
     test::require_throws_as<args::ParseError>([&] { p.ParseArgs(std::vector<std::string>{"--completion", "bash", "-1", "test", "-"}); });
+    test::require_throws_as<args::Completion>([&] { p.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "-"}); });
     return 0;
 }

--- a/test/noexcept_completion_bad_cword.cxx
+++ b/test/noexcept_completion_bad_cword.cxx
@@ -21,5 +21,9 @@ int main()
 
     p.ParseArgs(std::vector<std::string>{"--completion", "bash", "-1", "test", "-"});
     test::require(p.GetError() == args::Error::Parse);
+
+    p.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "-"});
+    test::require(p.GetError() == args::Error::Completion);
+    test::require(c.Get().empty());
     return 0;
 }


### PR DESCRIPTION
This patch fixes inconsistent handling of invalid completion index `cword` values when `ARGS_NOEXCEPT` mode is enabled.

Previously invalid cword values were detected but not properly handled in the noexcept code path, allowing parsing to continue with an invalid state. In contrast, the throwing mode correctly aborted execution

## Fix
- Added early return (`return end;`) when invalid cword is detected in `ARGS_NOEXCEPT` mode
- Aligns behavior with throwing mode (`throw Completion("")`)
- Ensures parsing does not proceed with invalid state

## Tests

Updated and extended test coverage:

- #### completion_bad_cword.cxx
  - Added case verifying correct handling of out-of-range cword in throwing mode

- #### noexcept_completion_bad_cword.cxx
  - Added case verifying:
    - Error::Completion is set
    - No completion output is produced
    - Parser exits safely