### PR TITLE
Avoid unsafe vector construction in argument completion

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2834,8 +2834,14 @@ namespace args
 #endif
                         }
 
-                        std::vector<std::string> curArgs(++it, end);
-                        curArgs.resize(completion->cword);
+                        ++it;
+                        std::vector<std::string> curArgs;
+                        curArgs.reserve(completion->cword);
+                        auto curIt = it;
+                        for (size_t idx = 0; idx < completion->cword && curIt != end; ++idx, ++curIt)
+                        {
+                            curArgs.push_back(*curIt);
+                        }
 
                         if (completion->syntax == "bash")
                         {


### PR DESCRIPTION
This patch replaces direct vector construction from iterators with a bounded iteration approach when building argument lists for completion.

Previously, the code constructed a vector from the current iterator to the end and then resized it to match completion->cword. This could lead to unnecessary copying, potential over-allocation, and inconsistent behavior when cword exceeds available arguments.

The new implementation:
- Iterates only up to completion->cword
- Stops safely at iterator bounds
- Avoids copying excess elements
- Prevents implicit padding with empty strings