### PR TITLE
Harden noexcept parsing against post-failure state mutation

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -3742,6 +3742,7 @@ namespace args
                     if (!reader(name, value, v))
                     {
                         error = Error::Parse;
+                        return;
                     }
 #else
                     reader(name, value, v);
@@ -3881,6 +3882,7 @@ namespace args
                 if (!reader(name, value_, v))
                 {
                     error = Error::Parse;
+                    return;
                 }
 #else
                 reader(name, value_, v);
@@ -4293,6 +4295,7 @@ namespace args
                 if (!reader(name, value_, this->value))
                 {
                     error = Error::Parse;
+                    return;
                 }
 #else
                 reader(name, value_, this->value);
@@ -4393,6 +4396,7 @@ namespace args
                 if (!reader(name, value_, v))
                 {
                     error = Error::Parse;
+                    return;
                 }
 #else
                 reader(name, value_, v);

--- a/meson.build
+++ b/meson.build
@@ -58,6 +58,7 @@ test_names = [
   'noexcept_matcher_validation',
   'noexcept_mode',
   'noexcept_nargs',
+  'noexcept_parser_failure_state',
   'noexcept_required_flags',
   'noexcept_subparser_validation',
   'noexcept_unsigned_negative',

--- a/test/noexcept_parser_failure_state.cxx
+++ b/test/noexcept_parser_failure_state.cxx
@@ -1,0 +1,53 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#define ARGS_NOEXCEPT
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    {
+        args::ArgumentParser parser("Test command");
+        args::NargsValueFlag<int> nums(parser, "NUMS", "test", {'n', "nums"}, {1, 2}, {42});
+
+        parser.ParseArgs(std::vector<std::string>{"--nums", "abc"});
+        test::require(parser.GetError() == args::Error::Parse);
+        test::require((*nums == std::vector<int>{}));
+    }
+
+    {
+        args::ArgumentParser parser("Test command");
+        args::ValueFlagList<int> vals(parser, "VAL", "test", {'v', "vals"}, {11});
+
+        parser.ParseArgs(std::vector<std::string>{"--vals", "abc"});
+        test::require(parser.GetError() == args::Error::Parse);
+        test::require((*vals == std::vector<int>{}));
+    }
+
+    {
+        args::ArgumentParser parser("Test command");
+        args::Positional<int> pos(parser, "POS", "test", 123);
+
+        parser.ParseArgs(std::vector<std::string>{"abc"});
+        test::require(parser.GetError() == args::Error::Parse);
+        test::require(*pos == 123);
+        test::require_false(static_cast<bool>(pos));
+    }
+
+    {
+        args::ArgumentParser parser("Test command");
+        args::PositionalList<int> poslist(parser, "POSLIST", "test", {99});
+
+        parser.ParseArgs(std::vector<std::string>{"abc"});
+        test::require(parser.GetError() == args::Error::Parse);
+        test::require((*poslist == std::vector<int>{}));
+        test::require_false(static_cast<bool>(poslist));
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This patch eliminates continue-after-failure behavior in multiple `ARGS_NOEXCEPT` parser paths.

Previously, parse failures set `Error::Parse` but execution continued, allowing internal parser state to be modified after rejected input. Depending on parser type, this could result in partially applied values or incorrect matched-state tracking.

The fix introduces fail-fast semantics by returning immediately after parse failure, ensuring rejected input cannot mutate observable parser state.
