### PR TITLE
Fix bash completion offset when LongSeparator is multi-character

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2585,7 +2585,7 @@ namespace args
                 {
                     if (completion->syntax == "bash" && ParseOption(choice) == OptionType::LongFlag && choice.find(longseparator) != std::string::npos)
                     {
-                        completion->reply.push_back(choice.substr(choice.find(longseparator) + 1));
+                        completion->reply.push_back(choice.substr(choice.find(longseparator) + longseparator.size()));
                     } else
                     {
                         completion->reply.push_back(choice);

--- a/test/completion_long_separator_multichar.cxx
+++ b/test/completion_long_separator_multichar.cxx
@@ -1,0 +1,27 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ *
+ * Regression test for AddCompletionReply substring offset.
+ * Verifies bash completion of long-flag values with a multi-character
+ * LongSeparator strips the entire separator (not just one byte).
+ */
+
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    args::ArgumentParser p("parser");
+    args::CompletionFlag c(p, {"completion"});
+    p.LongSeparator("==");
+    args::MapFlag<std::string, int> m(p, "mappos", "mappos", {'m', "map"},
+                                      {{"alpha", 1}, {"beta", 2}});
+
+    test::require_throws_with(
+        [&] { p.ParseArgs(std::vector<std::string>{"--completion", "bash", "1", "test", "--map=="}); },
+        "alpha\nbeta");
+    return 0;
+}


### PR DESCRIPTION
Fixes bash completion output when using a multi-character `LongSeparator`. `Command::AddCompletionReply` incorrectly assumed the separator length was always one byte and used `+ 1` when stripping the `--flag<sep>` prefix from completion choices. This caused trailing separator characters to leak into completion results for configurations such as `LongSeparator("==")`.

## Changes 

* Replaced the hard-coded substring offset:

  ```cpp id="ot8qz1"
  choice.find(longseparator) + 1
  ```

  with:

  ```cpp id="l3f2kp"
  choice.find(longseparator) + longseparator.size()
  ```
* Ensures the full separator length is skipped correctly for all
  supported `LongSeparator` values.
* No behavior change for the default `"="` separator.

## Test added

Added `test/completion_long_separator_multichar.cxx` to verify bash
completion behavior with `LongSeparator("==")`.

The test:

* creates a `MapFlag<std::string, int>` with values `alpha` and `beta`
* triggers completion using `--map==`
* verifies the completion output is:

  ```text id="5d9q2e"
  alpha
  beta
  ```

