### PR TITLE
Fix noexcept duplicate Single-flag state mutation

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2495,6 +2495,17 @@ namespace args
 
                 if (auto flag = Match(arg))
                 {
+#ifdef ARGS_NOEXCEPT
+                    // Match() may set the flag's error (e.g. Error::Extra when
+                    // Options::Single is violated). In non-noexcept mode that
+                    // path throws and parsing stops before the value is read;
+                    // in noexcept mode we must mirror that and skip the value
+                    // parsing so the previously-stored value is preserved.
+                    if (flag->GetError() != Error::None)
+                    {
+                        return false;
+                    }
+#endif
                     std::vector<std::string> values;
                     const std::string errorMessage = ParseArgsValues(*flag, arg, it, end, allowSeparateLongValue, allowJoinedLongValue,
                                                                      separator != argchunk.npos, joined, false, values);
@@ -2545,6 +2556,15 @@ namespace args
 
                     if (auto flag = Match(arg))
                     {
+#ifdef ARGS_NOEXCEPT
+                        // See ParseLong: if Match recorded an error
+                        // (e.g. Options::Single violation), bail before the
+                        // value is parsed so the prior value is preserved.
+                        if (flag->GetError() != Error::None)
+                        {
+                            return false;
+                        }
+#endif
                         const std::string value(argit + 1, std::end(argchunk));
                         std::vector<std::string> values;
                         const std::string errorMessage = ParseArgsValues(*flag, std::string(1, arg), it, end,
@@ -3356,6 +3376,16 @@ namespace args
                 auto me = FlagBase::Match(arg);
                 if (me)
                 {
+#ifdef ARGS_NOEXCEPT
+                    // Suppress increment when FlagBase::Match recorded an
+                    // error on this same call (e.g. Options::Single violated).
+                    // In non-noexcept mode that path would have thrown before
+                    // reaching here and the count would not have advanced.
+                    if (GetError() != Error::None)
+                    {
+                        return me;
+                    }
+#endif
                     ++count;
                 }
                 return me;

--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,7 @@ test_names = [
   'noexcept_nargs',
   'noexcept_parser_failure_state',
   'noexcept_required_flags',
+  'noexcept_single_flag_repeat',
   'noexcept_subparser_validation',
   'noexcept_unsigned_negative',
   'option_terminator',

--- a/test/BUCK
+++ b/test/BUCK
@@ -38,6 +38,7 @@ test_names = [
     'noexcept_mode',
     'noexcept_nargs',
     'noexcept_required_flags',
+    'noexcept_single_flag_repeat',
     'noexcept_subparser_validation',
     'noexcept_unsigned_negative',
     'option_terminator',

--- a/test/noexcept_single_flag_repeat.cxx
+++ b/test/noexcept_single_flag_repeat.cxx
@@ -1,0 +1,75 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ *
+ * Regression test: when a flag carrying Options::Single is passed twice in
+ * ARGS_NOEXCEPT mode, FlagBase::Match used to set Error::Extra and then fall
+ * through to the normal value-parsing path, silently overwriting the
+ * previously stored value (and, for CounterFlag, double-counting the
+ * duplicate).  Non-noexcept mode throws ExtraError before the second value
+ * is parsed, so the prior value is preserved.  The two modes must agree:
+ * after a duplicate Single flag, GetError() reports Extra and the stored
+ * value reflects only the first, accepted occurrence.
+ */
+
+#define ARGS_NOEXCEPT
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    // ValueFlag<std::string> + Options::Single: second value must not overwrite.
+    {
+        args::ArgumentParser parser("Test command");
+        args::ValueFlag<std::string> f(parser, "X", "test", {'x'}, "default", args::Options::Single);
+
+        parser.ParseArgs(std::vector<std::string>{"-x", "first", "-x", "second"});
+        test::require(parser.GetError() == args::Error::Extra);
+        test::require(*f == "first");
+    }
+
+    // Long-form flag through ParseLong path.
+    {
+        args::ArgumentParser parser("Test command");
+        args::ValueFlag<std::string> f(parser, "X", "test", {"xx"}, "default", args::Options::Single);
+
+        parser.ParseArgs(std::vector<std::string>{"--xx", "first", "--xx=second"});
+        test::require(parser.GetError() == args::Error::Extra);
+        test::require(*f == "first");
+    }
+
+    // ValueFlag<int>: ensure numeric value-readers are not invoked the second time.
+    {
+        args::ArgumentParser parser("Test command");
+        args::ValueFlag<int> f(parser, "N", "test", {'n'}, 0, args::Options::Single);
+
+        parser.ParseArgs(std::vector<std::string>{"-n", "1", "-n", "2"});
+        test::require(parser.GetError() == args::Error::Extra);
+        test::require(*f == 1);
+    }
+
+    // CounterFlag: count must not advance past the duplicate.
+    {
+        args::ArgumentParser parser("Test command");
+        args::CounterFlag c(parser, "C", "test", {'c'}, 0, args::Options::Single);
+
+        parser.ParseArgs(std::vector<std::string>{"-c", "-c"});
+        test::require(parser.GetError() == args::Error::Extra);
+        test::require(*c == 1);
+    }
+
+    // MapFlag: the mapped value must reflect only the accepted first match.
+    {
+        args::ArgumentParser parser("Test command");
+        std::unordered_map<std::string, int> m{{"one", 1}, {"two", 2}};
+        args::MapFlag<std::string, int> f(parser, "M", "test", {'m'}, m, 0, args::Options::Single);
+
+        parser.ParseArgs(std::vector<std::string>{"-m", "one", "-m", "two"});
+        test::require(parser.GetError() == args::Error::Extra);
+        test::require(*f == 1);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
When a flag configured with `Options::Single` was passed more than once under `ARGS_NOEXCEPT`, the parser correctly recorded `Error::Extra` but still continued through the normal value parsing path.

As a result:
- `ValueFlag`, `MapFlag`, and other value-bearing flags silently overwrote the previously accepted value with the rejected duplicate.
- `CounterFlag` continued incrementing even after the duplicate was rejected.
- Throwing and noexcept builds diverged in observable parser state.

Non-noexcept mode throws `ExtraError` before the second value is parsed so the original value remains intact. This patch aligns noexcept mode with the throwing semantics by preventing further state mutation once `Match()` has already recorded an error.

Changes:
- Added ARGS_NOEXCEPT guards in `ParseLong` and `ParseShort` to stop processing before `ParseArgsValues` / `ParseValue` when `Match()` recorded an error.
- Updated `CounterFlag::Match` to suppress `++count` when `FlagBase::Match` set an error on the same call.
- Added regression coverage for:
  - short and long `ValueFlag<std::string>`
  - `ValueFlag<int>`
  - `CounterFlag`
  - `MapFlag`
- Registered the new regression test in Meson and Buck builds.

This preserves parser transactional semantics by ensuring rejected duplicate flags cannot commit additional state in noexcept mode.

Testing:
Added `test/noexcept_single_flag_repeat.cxx` covering duplicate `Options::Single` handling across multiple flag types under `ARGS_NOEXCEPT`
