### PR TITLE
Preserve ParseValue errors in ARGS_NOEXCEPT mode

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2512,6 +2512,17 @@ namespace args
                     if (!readCompletion)
                     {
                         flag->ParseValue(values);
+#ifdef ARGS_NOEXCEPT
+                        // Non-noexcept ParseValue paths throw on Help, reader
+                        // failure, or Map miss, which halts parsing. Mirror
+                        // that here so a later parser-level error (e.g. an
+                        // unknown flag) cannot shadow the flag's error in
+                        // ArgumentParser::GetError().
+                        if (flag->GetError() != Error::None)
+                        {
+                            return false;
+                        }
+#endif
                     }
 
                     if (flag->KickOut())
@@ -2565,6 +2576,15 @@ namespace args
                         if (!readCompletion)
                         {
                             flag->ParseValue(values);
+#ifdef ARGS_NOEXCEPT
+                            // See ParseLong: ensure a flag-level error from
+                            // ParseValue (Help, Parse, Map) halts parsing so
+                            // it cannot be shadowed by a later parser error.
+                            if (flag->GetError() != Error::None)
+                            {
+                                return false;
+                            }
+#endif
                         }
 
                         if (flag->KickOut())

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,7 @@ test_names = [
   'nargs',
   'noexcept_completion',
   'noexcept_completion_bad_cword',
+  'noexcept_flag_error_no_shadow',
   'noexcept_matcher_validation',
   'noexcept_mode',
   'noexcept_nargs',

--- a/test/BUCK
+++ b/test/BUCK
@@ -34,6 +34,7 @@ test_names = [
     'nargs',
     'noexcept_completion',
     'noexcept_completion_bad_cword',
+    'noexcept_flag_error_no_shadow',
     'noexcept_matcher_validation',
     'noexcept_mode',
     'noexcept_nargs',

--- a/test/noexcept_flag_error_no_shadow.cxx
+++ b/test/noexcept_flag_error_no_shadow.cxx
@@ -1,0 +1,76 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ *
+ * Regression test: a flag's per-flag error set by ParseValue (Help, Parse,
+ * Map) must not be shadowed by a later parser-level error in ARGS_NOEXCEPT
+ * mode. In non-noexcept mode the corresponding ParseValue throws and parsing
+ * stops; the noexcept path must behave equivalently.
+ */
+
+#define ARGS_NOEXCEPT
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    // HelpFlag followed by an unknown long flag: the user asked for help, so
+    // GetError() must report Help, not Parse from the unknown flag.
+    {
+        args::ArgumentParser parser("Test");
+        args::HelpFlag help(parser, "help", "show help", {"help"});
+        parser.ParseArgs(std::vector<std::string>{"--help", "--unknown"});
+        test::require(parser.GetError() == args::Error::Help);
+        test::require(parser.GetErrorMsg() == "help");
+    }
+
+    // Same scenario via short flag.
+    {
+        args::ArgumentParser parser("Test");
+        args::HelpFlag help(parser, "help", "show help", {'h'});
+        parser.ParseArgs(std::vector<std::string>{"-h", "--unknown"});
+        test::require(parser.GetError() == args::Error::Help);
+        test::require(parser.GetErrorMsg() == "help");
+    }
+
+    // MapFlag with a key not in the map followed by an unknown flag: the
+    // Map error originates from the bad key, not Parse from the unknown.
+    {
+        args::ArgumentParser parser("Test");
+        args::MapFlag<std::string, int> m(parser, "M", "map flag", {'m', "map"}, {{"a", 1}});
+        parser.ParseArgs(std::vector<std::string>{"--map=bad", "--unknown"});
+        test::require(parser.GetError() == args::Error::Map);
+    }
+
+    // MapFlag short-form variant.
+    {
+        args::ArgumentParser parser("Test");
+        args::MapFlag<std::string, int> m(parser, "M", "map flag", {'m'}, {{"a", 1}});
+        parser.ParseArgs(std::vector<std::string>{"-mbad", "--unknown"});
+        test::require(parser.GetError() == args::Error::Map);
+    }
+
+    // Reader failure followed by an unknown flag: the parser-level errorMsg
+    // for the unknown flag must not displace the original value-parse error.
+    {
+        args::ArgumentParser parser("Test");
+        args::ValueFlag<int> num(parser, "NUM", "number", {"num"});
+        parser.ParseArgs(std::vector<std::string>{"--num=abc", "--unknown"});
+        test::require(parser.GetError() == args::Error::Parse);
+        // Before the fix, errorMsg would be "Flag could not be matched: unknown".
+        test::require(parser.GetErrorMsg().find("unknown") == std::string::npos);
+    }
+
+    // Without any trailing arg, the flag's error is reported as before
+    // (sanity check that the fix does not regress the simple path).
+    {
+        args::ArgumentParser parser("Test");
+        args::HelpFlag help(parser, "help", "show help", {"help"});
+        parser.ParseArgs(std::vector<std::string>{"--help"});
+        test::require(parser.GetError() == args::Error::Help);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Fix error shadowing in ARGS_NOEXCEPT mode by stopping parsing after ParseValue() sets a flag-level error.

Previously, noexcept parsing continued after Help, Map, or value parsing failures recorded an error on the matched flag. A later parser-level error (such as an unknown flag) could then overwrite the original error returned by GetError().

This caused behavioral divergence between noexcept and exception-enabled builds, where ParseValue() already throws and halts parsing immediately.

## Changes

- Add guarded post-ParseValue() error checks in:
  - `ParseLong`
  - `ParseShort`

- Return early in ARGS_NOEXCEPT mode when ParseValue() sets a flag error.

- Add regression coverage for:
  - HelpFlag
  - MapFlag failures
  - Value parsing failures
  - Long and short flag variants
  - Error message preservation
