### PR TITLE
Reject whitespace-only input in numeric value parsing

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -3452,11 +3452,15 @@ namespace args
             if (std::is_unsigned<T>::value)
             {
                 const unsigned long long parsed = std::strtoull(begin, &end, 0);
+                if (end == begin)
+                {
+                    return false;
+                }
                 while (end != nullptr && *end != '\0' && std::isspace(static_cast<unsigned char>(*end)))
                 {
                     ++end;
                 }
-                if (end == begin || *end != '\0' || errno == ERANGE || parsed > static_cast<unsigned long long>(std::numeric_limits<T>::max()))
+                if (*end != '\0' || errno == ERANGE || parsed > static_cast<unsigned long long>(std::numeric_limits<T>::max()))
                 {
                     return false;
                 }
@@ -3466,11 +3470,15 @@ namespace args
             else
             {
                 const long long parsed = std::strtoll(begin, &end, 0);
+                if (end == begin)
+                {
+                    return false;
+                }
                 while (end != nullptr && *end != '\0' && std::isspace(static_cast<unsigned char>(*end)))
                 {
                     ++end;
                 }
-                if (end == begin || *end != '\0' || errno == ERANGE ||
+                if (*end != '\0' || errno == ERANGE ||
                     parsed < static_cast<long long>(std::numeric_limits<T>::min()) ||
                     parsed > static_cast<long long>(std::numeric_limits<T>::max()))
                 {

--- a/test/whitespace_numeric.cxx
+++ b/test/whitespace_numeric.cxx
@@ -1,0 +1,63 @@
+#include "test_common.hxx"
+#include <args.hxx>
+#include "test_helpers.hxx"
+
+int main()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::ValueFlag<int> foo(parser, "FOO", "test flag", {'f', "foo"});
+    args::ValueFlag<unsigned int> uid(parser, "UID", "numeric id", {'u', "uid"});
+
+    // Valid inputs
+    {
+        std::vector<std::string> args{"--foo", "123"};
+        parser.ParseArgs(args);
+        test::require(args::get(foo) == 123);
+    }
+    
+    {
+        std::vector<std::string> args{"--foo", " 123"};
+        parser.ParseArgs(args);
+        test::require(args::get(foo) == 123);
+    }
+    
+    {
+        std::vector<std::string> args{"--foo", "123 "};
+        parser.ParseArgs(args);
+        test::require(args::get(foo) == 123);
+    }
+    
+    {
+        std::vector<std::string> args{"--foo", "+123"};
+        parser.ParseArgs(args);
+        test::require(args::get(foo) == 123);
+    }
+
+    {
+        std::vector<std::string> args{"--uid", "0x10"};
+        parser.ParseArgs(args);
+        test::require(args::get(uid) == 16);
+    }
+
+    {
+        std::vector<std::string> args{"--uid", "010"};
+        parser.ParseArgs(args);
+        test::require(args::get(uid) == 8);
+    }
+
+    // Failing inputs
+    test::require_throws_as<args::ParseError>([&] { 
+        std::vector<std::string> args{"--foo", "   "};
+        parser.ParseArgs(args); 
+    });
+    test::require_throws_as<args::ParseError>([&] { 
+        std::vector<std::string> args{"--foo", ""};
+        parser.ParseArgs(args); 
+    });
+    test::require_throws_as<args::ParseError>([&] { 
+        std::vector<std::string> args{"--uid", "   "};
+        parser.ParseArgs(args); 
+    });
+    
+    return 0;
+}


### PR DESCRIPTION
## Summary
Reject whitespace-only input during numeric value parsing.

## Changes
- Add explicit `end == begin` validation immediately after `std::strtoll` / `std::strtoull` parsing.
- Prevent inputs containing only whitespace from being accepted as `0`.
- Preserve existing parsing behavior for:
  - decimal values
  - hexadecimal values (`0x10`)
  - octal values (`010`)
  - leading/trailing whitespace
  - leading `+` signs

## Tests
Added focused regression coverage for:
- whitespace-only input rejection
- empty input rejection
- valid decimal parsing
- hexadecimal parsing
- octal parsing
- leading/trailing whitespace handling
- leading `+` handling