### PR TITLE
Restore existing integer parsing semantics in the C++17 from_chars path

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -59,6 +59,10 @@
 #include <cstdlib>
 #include <limits>
 #include <iostream>
+#if __cplusplus >= 201703L
+#include <charconv>
+#include <system_error>
+#endif
 
 #if defined(_MSC_VER) && _MSC_VER <= 1800
 #define noexcept
@@ -3635,12 +3639,36 @@ namespace args
 
             const char *begin = value.c_str();
             
-            // Security enhancement: Use C++17 std::from_chars when available (thread-safe, no errno)
-            // Fallback to strtoll/strtoull for C++11/14 compatibility with careful errno handling
+            // Preserve existing parsing semantics with std::from_chars
 #if __cplusplus >= 201703L
             const char *end_pos = value.c_str() + value.length();
-            T parsed = 0;
-            auto result = std::from_chars(begin, end_pos, parsed);
+            while (begin != end_pos && std::isspace(static_cast<unsigned char>(*begin)))
+            {
+                ++begin;
+            }
+            const bool negative = begin != end_pos && *begin == '-';
+            if (negative || (begin != end_pos && *begin == '+'))
+            {
+                ++begin;
+            }
+
+            int base = 10;
+            if (end_pos - begin > 1 && *begin == '0')
+            {
+                if (*(begin + 1) == 'x' || *(begin + 1) == 'X')
+                {
+                    begin += 2;
+                    base = 16;
+                }
+                else
+                {
+                    base = 8;
+                }
+            }
+
+            typedef typename std::make_unsigned<T>::type UnsignedT;
+            UnsignedT parsed = 0;
+            auto result = std::from_chars(begin, end_pos, parsed, base);
             
             // Find end of valid parse
             end_pos = result.ptr;
@@ -3659,13 +3687,29 @@ namespace args
                 return false;
             }
             
-            destination = parsed;
+            if (negative)
+            {
+                const UnsignedT minMagnitude =
+                    static_cast<UnsignedT>(std::numeric_limits<T>::max()) + static_cast<UnsignedT>(1);
+                if (parsed > minMagnitude)
+                {
+                    return false;
+                }
+                destination = parsed == minMagnitude ?
+                    std::numeric_limits<T>::min() :
+                    static_cast<T>(-static_cast<T>(parsed));
+            }
+            else
+            {
+                if (parsed > static_cast<UnsignedT>(std::numeric_limits<T>::max()))
+                {
+                    return false;
+                }
+                destination = static_cast<T>(parsed);
+            }
             return true;
 #else
-            // C++11/14 fallback: Use strtoll/strtoull
-            // SECURITY WARNING: errno is global and not thread-safe. This fallback is provided
-            // for C++11/14 compatibility but multithreaded applications should compile with
-            // C++17 and use std::from_chars for thread-safe parsing.
+            // C++11/14 fallback using strtoll/strtoull
             
             // Save errno to detect if strtoull/strtoll sets it
             const int saved_errno = errno;

--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,7 @@ test_names = [
   'hidden_options',
   'implicit_values',
   'integer_overflow',
+  'integer_parser',
   'invalid_arg_parse',
   'kickout_flags',
   'mapping_types',

--- a/test/BUCK
+++ b/test/BUCK
@@ -27,6 +27,7 @@ test_names = [
     'hidden_options',
     'implicit_values',
     'integer_overflow',
+    'integer_parser',
     'invalid_arg_parse',
     'kickout_flags',
     'mapping_types',

--- a/test/integer_parser.cxx
+++ b/test/integer_parser.cxx
@@ -1,0 +1,38 @@
+#include "test_common.hxx"
+#include <args.hxx>
+#include "test_helpers.hxx"
+#include <iostream>
+#include <string>
+
+template <typename T>
+void test_parse(const std::string& input, bool expect_success, T expected_val) {
+    args::ValueReader reader;
+    T val = 0;
+    bool success = reader.ParseNumericValue(input, val);
+    
+    if (success != expect_success) {
+        std::cerr << "FAIL (success mismatch): input='" << input 
+                  << "' success=" << success << " (expected " << expect_success << ")" << std::endl;
+        exit(1);
+    }
+    
+    if (success && val != expected_val) {
+        std::cerr << "FAIL (value mismatch): input='" << input 
+                  << "' val=" << (long long)val << " (expected " << (long long)expected_val << ")" << std::endl;
+        exit(1);
+    }
+}
+
+int main() {
+    // Regression tests for C++17 from_chars compatibility
+    // These cases were historically supported via strtoll(..., 0) but failed in naive C++17 std::from_chars
+    
+    test_parse<int>("+123", true, 123);   // Explicit plus sign
+    test_parse<int>("0x10", true, 16);   // Hex auto-detection
+    test_parse<int>("-0x10", true, -16); // Signed hex
+    test_parse<int>("010", true, 8);     // Octal auto-detection
+    test_parse<int>("08", false, 0);     // Invalid octal digits must be rejected
+    
+    std::cout << "All regression tests passed!" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary

Restore existing integer parsing semantics in the C++17 `std::from_chars` path to match the historical `strtoll(..., 0)` / `strtoull(..., 0)` fallback behavior.

## Changes

- Add required C++17 headers for `std::from_chars`
  - `<charconv>`
  - `<system_error>`

- Preserve previously supported parsing behavior in the C++17 path:
  - leading whitespace
  - optional `+`
  - hexadecimal values (`0x10`)
  - octal-prefixed values (`010`)

- Keep strict malformed-input rejection behavior:
  - invalid octal input such as `08`
  - overflow handling
  - unsigned negative rejection

- Maintain existing C++11/14 fallback behavior unchanged

## Tests

Added focused regression coverage for previously supported inputs that failed in the naive C++17 `std::from_chars` path:

- `+123`
- `0x10`
- `-0x10`
- `010`
- `08`