### PR TITLE
Fix ARGS_NOEXCEPT iterator OOB and dangling iterator bugs

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2681,7 +2681,16 @@ namespace args
                     {
                         if (Complete(flag, valueIt, end))
                         {
-                            it = end;
+                            // Park `it` on the completion position rather than
+                            // `end`. In ARGS_NOEXCEPT mode Complete returns
+                            // true (no throw), so the caller's for-loop will
+                            // run its ++it after we return; advancing an
+                            // already-end iterator is undefined behavior and
+                            // causes a subsequent out-of-bounds read of the
+                            // arg vector. Since Complete only fires when
+                            // ++nextIt == end, valueIt is the last element,
+                            // and ++(it=valueIt) safely lands on end.
+                            it = valueIt;
                             return "";
                         }
 
@@ -3184,7 +3193,15 @@ namespace args
                             throw Completion("");
                         }
 #else
-                        return Parse(curArgs.begin(), curArgs.end());
+                        // Discard the nested Parse's return value: it points
+                        // into the local curArgs vector, which is destroyed
+                        // when this function returns, leaving the caller with
+                        // a dangling iterator that would be compared against
+                        // the outer `end` in ParseCLI. Return the outer
+                        // `end` instead so the iterator stays in the caller's
+                        // container.
+                        Parse(curArgs.begin(), curArgs.end());
+                        return end;
 #endif
                     }
                 }

--- a/meson.build
+++ b/meson.build
@@ -56,6 +56,7 @@ test_names = [
   'nargs',
   'noexcept_completion',
   'noexcept_completion_bad_cword',
+  'noexcept_completion_value_oob',
   'noexcept_flag_error_no_shadow',
   'noexcept_matcher_validation',
   'noexcept_mode',

--- a/test/BUCK
+++ b/test/BUCK
@@ -35,6 +35,7 @@ test_names = [
     'nargs',
     'noexcept_completion',
     'noexcept_completion_bad_cword',
+    'noexcept_completion_value_oob',
     'noexcept_flag_error_no_shadow',
     'noexcept_matcher_validation',
     'noexcept_mode',

--- a/test/noexcept_completion_value_oob.cxx
+++ b/test/noexcept_completion_value_oob.cxx
@@ -1,0 +1,61 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ *
+ * Regression test for an out-of-bounds vector iterator increment that
+ * occurred under ARGS_NOEXCEPT when bash completion fired on the value
+ * position of a flag.
+ *
+ * Reproducer flow (without the fix):
+ *  - Outer Parse enters the completion handler, builds curArgs = {"-m", ""},
+ *    and recurses into Parse(curArgs.begin(), curArgs.end()).
+ *  - Inner Parse dispatches "-m" to ParseShort, which calls ParseArgsValues
+ *    to consume the (empty) value token.
+ *  - Inside ParseArgsValues, Complete() returns true (no throw under
+ *    ARGS_NOEXCEPT) and the handler sets `it = end`, then returns "".
+ *  - ParseShort returns true to the inner Parse loop, which then executes
+ *    `++it` on an already-end iterator -- undefined behavior, and the
+ *    subsequent `*it` reads past the end of curArgs.
+ *
+ * Additionally, the inner Parse's `return Parse(curArgs.begin(),
+ * curArgs.end())` propagates an iterator into the temporary curArgs back to
+ * ParseCLI, where it is compared against std::end(args) after curArgs has
+ * been destroyed -- a dangling-iterator comparison.
+ */
+
+#define ARGS_NOEXCEPT
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    args::ArgumentParser p("parser");
+    args::CompletionFlag c(p, {"completion"});
+    args::MapFlag<std::string, int> m(p, "mappos", "mappos", {'m', "map"},
+                                      {{"alpha", 1}, {"beta", 2}});
+
+    // cword=2 lands on the empty value position of "-m". Without the fix,
+    // the nested Parse advances its loop iterator past curArgs.end().
+    p.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "-m", ""});
+    test::require(p.GetError() == args::Error::Completion);
+    test::require(args::get(c) == "alpha\nbeta");
+
+    // Long form via separate value token: nested Parse sees {"--map", ""}.
+    p.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "--map", ""});
+    test::require(p.GetError() == args::Error::Completion);
+    test::require(args::get(c) == "alpha\nbeta");
+
+    // Exercise ParseCLI's iterator comparison: prior to the fix the
+    // return value of ParseArgs pointed into the destroyed curArgs and the
+    // == comparison against the outer args.end() in ParseCLI was a
+    // dangling-iterator compare. Just confirm it terminates cleanly with
+    // the expected completion state.
+    const std::vector<const char *> argv{"prog", "--completion", "bash", "2", "test", "-m", ""};
+    p.ParseCLI(static_cast<int>(argv.size()), argv.data());
+    test::require(p.GetError() == args::Error::Completion);
+    test::require(args::get(c) == "alpha\nbeta");
+
+    return 0;
+}


### PR DESCRIPTION
Fix two real memory-safety bugs in the `ARGS_NOEXCEPT` completion path:
- an out-of-bounds iterator increment/read after completion handling
- a dangling iterator returned from a nested `Parse()` call

Both issues are reachable during bash completion parsing and result in undefined behavior.

## Changes Done

### Fix iterator OOB after completion

In `ParseArgsValues`, the completion path previously set:

```cpp
it = end;
```

In `ARGS_NOEXCEPT` mode the callers loop subsequently performs ++it, which increments an already-end iterator and leads to an out-of-bounds read.

Updated the logic to:

```cpp
it = valueIt;
```

Since `Complete()` only fires when `++nextIt == end` valueIt is guaranteed to be the final valid element, allowing the callers ++it to safely land on end.

### Fix dangling iterator return

The nested completion parse previously returned:

```cpp
return Parse(curArgs.begin(), curArgs.end());
```

This propagated an iterator into the local curArgs vector back to the caller. Once the function returned, `curArgs` was destroyed and the iterator became dangling before later comparisons against the outer end iterator.

Updated the code to:

- discard the nested `Parse()` return value
- return the outer end iterator instead

## Tests Added

Added new regression test:

- `test/noexcept_completion_value_oob.cxx`