### PR TITLE
Stop positional parsing after parse errors in ARGS_NOEXCEPT mode

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -3081,6 +3081,12 @@ namespace args
                         if (pos)
                         {
                             pos->ParseValue(chunk);
+#ifdef ARGS_NOEXCEPT
+                            if (pos->GetError() != Error::None)
+                            {
+                                return it;
+                            }
+#endif
 
                             if (pos->KickOut())
                             {

--- a/test/noexcept_parser_failure_state.cxx
+++ b/test/noexcept_parser_failure_state.cxx
@@ -41,13 +41,27 @@ int main()
 
     {
         args::ArgumentParser parser("Test command");
+        args::Positional<int> first(parser, "FIRST", "test", 123);
+        args::Positional<int> second(parser, "SECOND", "test", 456);
+
+        parser.ParseArgs(std::vector<std::string>{"abc", "10"});
+        test::require(parser.GetError() == args::Error::Parse);
+        test::require(*first == 123);
+        test::require_false(static_cast<bool>(first));
+        test::require(*second == 456);
+        test::require_false(static_cast<bool>(second));
+    }
+
+    {
+        args::ArgumentParser parser("Test command");
         args::PositionalList<int> poslist(parser, "POSLIST", "test", {99});
 
-        parser.ParseArgs(std::vector<std::string>{"abc"});
+        parser.ParseArgs(std::vector<std::string>{"abc", "10"});
         test::require(parser.GetError() == args::Error::Parse);
         test::require((*poslist == std::vector<int>{}));
         test::require_false(static_cast<bool>(poslist));
     }
+
 
     return 0;
 }


### PR DESCRIPTION
## Summary

In `ARGS_NOEXCEPT` mode, positional parsing continued after a conversion failure because `ArgumentParser::Parse()` did not stop after `ParseValue()` set a parse error.

This allowed later tokens to be consumed into the failed positional.

Example before this change:

* positionals: `FIRST<int> SECOND<int>`
* input: `{"abc", "10"}`
* result:

  * parser error set to `Error::Parse`
  * `FIRST` unexpectedly became `10`
  * `SECOND` remained unmatched

Flag parsing already returns immediately on parse errors in `ARGS_NOEXCEPT` mode. This change applies the same behavior to positional parsing.

## Changes

* Stop positional parsing immediately after `pos->ParseValue()` reports a parse error in `ARGS_NOEXCEPT` mode
* Preserve positional state after failed conversion
* Add regression coverage for:

  * `Positional<int>`
  * `PositionalList<int>`

## Result

After this change:

* failed positionals are no longer mutated by later tokens
* subsequent positional arguments are not consumed after parse failure
* noexcept positional parsing behavior is consistent with existing flag error handling