### PR TITLE
Align ARGS_NOEXCEPT completion behavior with throwing mode

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -3186,6 +3186,8 @@ namespace args
                         // `end` instead so the iterator stays in the caller's
                         // container.
                         Parse(curArgs.begin(), curArgs.end());
+                        error = Error::Completion;
+                        errorMsg.clear();
                         return end;
 #endif
                     }

--- a/test/noexcept_completion.cxx
+++ b/test/noexcept_completion.cxx
@@ -21,5 +21,25 @@ int main()
     p.ParseArgs(std::vector<std::string>{"--completion", "bash", "1", "test", "-"});
     test::require(p.GetError() == args::Error::Completion);
     test::require(args::get(c) == "-f\n-b");
+
+    args::ArgumentParser p2("parser");
+    args::CompletionFlag complete2(p2, {"completion"});
+
+    args::Command c1(p2, "command1", "desc", [](args::Subparser &sp)
+    {
+        args::ValueFlag<std::string> f1(sp, "name", "description", {'f', "foo"}, "abc");
+        sp.Parse();
+    });
+
+    args::Command c2(p2, "command2", "desc", [](args::Subparser &sp)
+    {
+        args::ValueFlag<std::string> f1(sp, "name", "description", {'b', "bar"}, "abc");
+        sp.Parse();
+    });
+
+    p2.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "command3", ""});
+    test::require(p2.GetError() == args::Error::Completion);
+    test::require(p2.GetErrorMsg().empty());
+    test::require(args::get(complete2).empty());
     return 0;
 }


### PR DESCRIPTION
## Summary

This fixes an inconsistency between throwing mode and `ARGS_NOEXCEPT` during shell completion parsing.

In throwing mode, recursive parsing of partial completion input suppresses ordinary parse failures and returns empty completion output. `ARGS_NOEXCEPT` did not mirror that behavior and could leak `Error::Parse` state for unknown commands during completion.

## Changes

* Restore `Error::Completion` state after recursive completion parsing in `ARGS_NOEXCEPT`
* Clear leaked parse error messages from inner completion parsing
* Add focused regression coverage for unknown-command completion in noexcept mode

## Result

`ARGS_NOEXCEPT` completion behavior now matches the existing throwing-mode semantics for partial/unknown command completion input.