### PR TITLE
incorrect Nargs validation error message

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -990,7 +990,7 @@ namespace args
 #ifndef ARGS_NOEXCEPT
             if (max < min)
             {
-                throw UsageError("Nargs: max > min");
+                throw UsageError("Nargs: max < min");
             }
 #endif
         }

--- a/test/nargs.cxx
+++ b/test/nargs.cxx
@@ -17,7 +17,7 @@ int main()
     args::NargsValueFlag<int> d(parser, "", "", {'d'}, {1, 3});
     args::Flag f(parser, "", "", {'f'});
 
-    test::require_throws_as<args::UsageError>([&] { args::Nargs(3, 2); });
+    test::require_throws_with([&] { args::Nargs(3, 2); }, "Nargs: max < min");
 
     test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"-a", "1", "2"}); });
     test::require((*a == std::vector<int>{1, 2}));


### PR DESCRIPTION
## Summary

Fix the `args::Nargs(min, max)` validation error message when `max < min`.

The existing validation correctly rejects invalid ranges, but the diagnostic text reported the opposite relation.

## Changes

* Update the thrown `UsageError` message to match the actual validation condition.
* Strengthen the existing `nargs` regression test to verify the exact diagnostic text.