### PR TITLE
Harden CLI parsing and enable unsafe-buffer diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,9 +67,10 @@ if(ARGS_ENABLE_SECURITY_HARDENING)
         args_add_compile_flag_if_supported(-Wcast-align)
         args_add_compile_flag_if_supported(-Wunused)
 
-        # -Wunsafe-buffer-usage (clang) flags all raw pointer arithmetic,
-        # including the standard `argv + 1, argv + argc` idiom. It produces
-        # false positives on bounded argv handling, so it is not enabled.
+        # -Wunsafe-buffer-usage (clang) flags all raw pointer arithmetic.
+        # The library now avoids raw argv range arithmetic in security-sensitive
+        # code paths, so this warning is useful for catching unsafe buffer usage.
+        args_add_compile_flag_if_supported(-Wunsafe-buffer-usage)
 
         if(ARGS_ENABLE_HARDENING_WERROR)
             args_add_compile_flag_if_supported(-Werror)

--- a/args.hxx
+++ b/args.hxx
@@ -3504,7 +3504,14 @@ namespace args
                 std::vector<std::string> args;
                 if (argc > 1 && argv != nullptr)
                 {
-                    args.assign(argv + 1, argv + argc);
+                    args.reserve(static_cast<size_t>(argc - 1));
+                    for (int idx = 1; idx < argc; ++idx)
+                    {
+                        if (argv[idx] != nullptr)
+                        {
+                            args.emplace_back(argv[idx]);
+                        }
+                    }
                 }
 
                 return ParseArgs(args) == std::end(args);

--- a/examples/gitlike.cxx
+++ b/examples/gitlike.cxx
@@ -18,7 +18,18 @@ int main(int argc, char **argv)
         {"init", Init},
         {"add", Add}};
 
-    const std::vector<std::string> args(argv + 1, argv + argc);
+    std::vector<std::string> args;
+    if (argc > 1)
+    {
+        args.reserve(static_cast<size_t>(argc - 1));
+        for (int idx = 1; idx < argc; ++idx)
+        {
+            if (argv[idx] != nullptr)
+            {
+                args.emplace_back(argv[idx]);
+            }
+        }
+    }
     args::ArgumentParser parser("This is a git-like program", "Valid commands are init and add");
     args::HelpFlag help(parser, "help", "Display this help menu", {'h', "help"});
     parser.Prog(argv[0]);

--- a/test/parse_cli_args.cxx
+++ b/test/parse_cli_args.cxx
@@ -1,0 +1,26 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    args::ArgumentParser parser("This is a test program.");
+    args::ValueFlag<std::string> foo(parser, "FOO", "test flag", {'f', "foo"});
+    args::Flag bar(parser, "BAR", "test flag", {'b', "bar"});
+
+    const char *argv[] = {"prog", "-f", "test", "--bar"};
+    const bool result = parser.ParseCLI(static_cast<int>(sizeof(argv) / sizeof(argv[0])), argv);
+
+    test::require(result);
+    test::require(foo);
+    test::require(*foo == "test");
+    test::require(bar);
+
+    return 0;
+}


### PR DESCRIPTION
This PR improves the security hardening posture of the project by removing raw `argv` range pointer arithmetic from CLI parsing paths and enabling Clang's `-Wunsafe-buffer-usage` diagnostics where supported.

The patch replaces direct pointer-range construction patterns such as:

```cpp
args.assign(argv + 1, argv + argc);
```

with explicit bounds-checked iteration using standard containers.

In addition, this PR introduces regression coverage for `ArgumentParser::ParseCLI(int, const char* const*)` and enables compiler-assisted detection of unsafe buffer usage patterns.

---

## Security Rationale

This change improves the auditability and safety of CLI argument parsing by:

* Eliminating raw pointer range arithmetic in parser code paths
* Improving compatibility with Clang Safe Buffers analysis
* Enabling `-Wunsafe-buffer-usage` diagnostics to help prevent future regressions
* Handling malformed or partially invalid `argv` entries more defensively
* Making bounds reasoning explicit and easier to review

The hardening approach aligns with modern secure-by-design buffer handling practices and supports ongoing migration away from unsafe buffer manipulation idioms.

---

## Changes

### `args.hxx`

* Replaced raw `argv + 1, argv + argc` vector assignment with explicit iteration
* Added defensive null checks before appending CLI arguments
* Reserved vector capacity before insertion to avoid repeated reallocations

### `examples/gitlike.cxx`

* Replaced raw `argv` pointer-range construction with explicit indexed iteration
* Added defensive handling for null argument entries

### `CMakeLists.txt`

* Enabled `-Wunsafe-buffer-usage` when supported by Clang
* Updated comments to reflect removal of previously incompatible raw pointer idioms

### Tests

Added a regression test covering:

* `ArgumentParser::ParseCLI(int, const char* const*)`

---

