### PR TITLE
Guard joined-value completion against prefix/separator overlap

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2949,7 +2949,20 @@ namespace args
                         if (optionType == OptionType::LongFlag && allowJoinedLongValue)
                         {
                             const auto separator = longseparator.empty() ? chunk.npos : chunk.find(longseparator);
-                            if (separator != chunk.npos)
+                            // Only attempt joined-value completion when the
+                            // separator lies at or past the long prefix, so
+                            // there is a (possibly empty) flag name between
+                            // them. With a custom longseparator that overlaps
+                            // the prefix (e.g. LongSeparator("-") under the
+                            // default "--" prefix), an attacker-controlled
+                            // completion word like "--x" puts the separator
+                            // inside the prefix, making `arg` shorter than
+                            // longprefix. arg.substr(longprefix.size()) would
+                            // then throw std::out_of_range, which escapes the
+                            // parser as a non-args exception (bypassing the
+                            // documented catch(args::Error) idiom) and is
+                            // thrown even under ARGS_NOEXCEPT.
+                            if (separator != chunk.npos && separator >= longprefix.size())
                             {
                                 std::string arg(chunk, 0, separator);
                                 if (auto flag = this->Match(arg.substr(longprefix.size())))

--- a/test/completion_separator_prefix_overlap.cxx
+++ b/test/completion_separator_prefix_overlap.cxx
@@ -1,0 +1,49 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ *
+ * Regression test for an out-of-bounds std::string::substr in the bash
+ * completion handler.
+ *
+ * When a custom LongSeparator overlaps the long prefix (here "-" under the
+ * default "--" prefix), an attacker-controlled completion word such as
+ * "--x" makes chunk.find(longseparator) land *inside* the prefix. The
+ * handler then built `arg` (= chunk up to the separator) shorter than
+ * longprefix and called arg.substr(longprefix.size()), which threw
+ * std::out_of_range.
+ *
+ * That std::out_of_range is not an args::Error, so it escaped past the
+ * documented `catch (args::Completion&) / catch (args::Error&)` idiom and
+ * terminated the program. After the fix the joined-value completion is
+ * simply skipped when the separator falls inside the prefix, so the normal
+ * args::Completion path runs instead.
+ */
+
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    args::ArgumentParser p("parser");
+    args::CompletionFlag c(p, {"completion"});
+    args::ValueFlag<std::string> f(p, "f", "f", {'f', "foo"}, "abc");
+    p.LongSeparator("-"); // legal, non-empty separator that overlaps "--"
+
+    // Must throw args::Completion (the normal completion control-flow), not
+    // a leaked std::out_of_range.
+    test::require_throws_as<args::Completion>([&]
+    {
+        p.ParseArgs(std::vector<std::string>{"--completion", "bash", "1", "test", "--x"});
+    });
+
+    // A separator exactly at the prefix boundary leaves an empty flag name;
+    // it must also complete cleanly rather than throw out_of_range.
+    test::require_throws_as<args::Completion>([&]
+    {
+        p.ParseArgs(std::vector<std::string>{"--completion", "bash", "1", "test", "---x"});
+    });
+
+    return 0;
+}

--- a/test/noexcept_completion_separator_prefix_overlap.cxx
+++ b/test/noexcept_completion_separator_prefix_overlap.cxx
@@ -1,0 +1,43 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ *
+ * ARGS_NOEXCEPT counterpart of completion_separator_prefix_overlap.
+ *
+ * std::string::substr throws std::out_of_range regardless of ARGS_NOEXCEPT,
+ * so the unguarded arg.substr(longprefix.size()) in the bash completion
+ * handler broke the no-throw contract: an ARGS_NOEXCEPT build (which may be
+ * compiled with -fno-exceptions) would std::terminate on the completion
+ * word "--x" when a custom LongSeparator overlaps the long prefix.
+ *
+ * After the fix ParseArgs returns normally and records the completion via
+ * the error state instead of throwing.
+ */
+
+#define ARGS_NOEXCEPT
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    args::ArgumentParser p("parser");
+    args::CompletionFlag c(p, {"completion"});
+    args::ValueFlag<std::string> f(p, "f", "f", {'f', "foo"}, "abc");
+    p.LongSeparator("-");
+
+    test::require_nothrow([&]
+    {
+        p.ParseArgs(std::vector<std::string>{"--completion", "bash", "1", "test", "--x"});
+    });
+    test::require(p.GetError() == args::Error::Completion);
+
+    test::require_nothrow([&]
+    {
+        p.ParseArgs(std::vector<std::string>{"--completion", "bash", "1", "test", "---x"});
+    });
+    test::require(p.GetError() == args::Error::Completion);
+
+    return 0;
+}


### PR DESCRIPTION
Harden the bash-completion path against invalid prefix/separator combinations that can cause `std::string::substr()` to throw `std::out_of_range`.

When a custom `LongSeparator()` overlaps the configured long-option prefix (for example, `LongSeparator("-")` with the default `"--"` prefix), `find(longseparator)` may return a position inside the prefix itself. The completion handler then constructs an `arg` string shorter than `longprefix` and subsequently calls:

```cpp
arg.substr(longprefix.size())
```

which throws `std::out_of_range`.

## Root Cause

The joined-value completion path assumed that any discovered separator would occur at or beyond the end of the long-option prefix. That invariant was not enforced.

For overlapping prefix/separator configurations, `arg` may become shorter than `longprefix`, making:

```cpp
arg.substr(longprefix.size())
```

invalid.

In throwing builds, the resulting `std::out_of_range` escapes as a non-`args` exception. Under `ARGS_NOEXCEPT`, the throwing `substr()` call breaks the no-throw expectation and may result in termination when exceptions are disabled.

## Fix

Only attempt joined-value completion when the separator is located at or beyond the end of the long-option prefix:

```cpp
if (separator != chunk.npos && separator >= longprefix.size())
```

This prevents invalid `substr()` calls while preserving existing behavior for valid completion inputs.

## Tests

Added two regression tests:

- `test/completion_separator_prefix_overlap.cxx`
  - Verifies that completion handling follows the normal `args::Completion` path instead of leaking `std::out_of_range`.

- `test/noexcept_completion_separator_prefix_overlap.cxx`
  - Verifies correct behavior under `ARGS_NOEXCEPT`, ensuring completion is reported through the parser error state without throwing.

Both tests fail on the unpatched code and pass with this change.

## Files Changed

- `args.hxx`
- `test/completion_separator_prefix_overlap.cxx`
- `test/noexcept_completion_separator_prefix_overlap.cxx`