### PR TITLE
stop collecting flag values at the -- terminator

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2653,6 +2653,7 @@ namespace args
                     ++valueIt;
 
                     while (valueIt != end &&
+                           *valueIt != terminator &&
                            values.size() < nargs.max &&
                            (values.size() < nargs.min || ParseOption(*valueIt) == OptionType::Positional))
                     {

--- a/test/noexcept_terminator_flag_values.cxx
+++ b/test/noexcept_terminator_flag_values.cxx
@@ -1,0 +1,40 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#define ARGS_NOEXCEPT
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    // Same defect under ARGS_NOEXCEPT: the "--" terminator was swallowed as a
+    // value while the flag was still below its minimum, so parsing wrongly
+    // succeeded with n = ["a", "--", "b", "c"]. It must instead stop at "--"
+    // and report the below-minimum parse error.
+    {
+        args::ArgumentParser parser("Test command");
+        args::NargsValueFlag<std::string> n(parser, "n", "", {'n'}, {2, 4});
+        args::PositionalList<std::string> pos(parser, "pos", "");
+        parser.ParseArgs(std::vector<std::string>{"-n", "a", "--", "b", "c"});
+        test::require(parser.GetError() == args::Error::Parse);
+        test::require(n->empty());
+    }
+
+    // Minimum satisfied before the terminator: parsing succeeds and the
+    // trailing arguments become positionals.
+    {
+        args::ArgumentParser parser("Test command");
+        args::NargsValueFlag<std::string> n(parser, "n", "", {'n'}, {1, 4});
+        args::PositionalList<std::string> pos(parser, "pos", "");
+        parser.ParseArgs(std::vector<std::string>{"-n", "a", "b", "--", "c", "d"});
+        test::require(parser.GetError() == args::Error::None);
+        test::require((*n == std::vector<std::string>{"a", "b"}));
+        test::require((*pos == std::vector<std::string>{"c", "d"}));
+    }
+
+    return 0;
+}

--- a/test/terminator_flag_values.cxx
+++ b/test/terminator_flag_values.cxx
@@ -1,0 +1,46 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    // While a flag is still gathering values below its minimum, the "--"
+    // terminator was consumed as a value instead of ending option parsing.
+    // "-n a -- b c" collected ["a", "--", "b", "c"] and left the positional
+    // list empty. "--" must stop the collection, so "n" only receives "a",
+    // which is below the minimum of 2.
+    {
+        args::ArgumentParser parser("Test command");
+        args::NargsValueFlag<std::string> n(parser, "n", "", {'n'}, {2, 4});
+        args::PositionalList<std::string> pos(parser, "pos", "");
+        test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"-n", "a", "--", "b", "c"}); });
+    }
+
+    // A single-value flag immediately followed by the terminator receives no
+    // value rather than the literal "--".
+    {
+        args::ArgumentParser parser("Test command");
+        args::ValueFlag<std::string> n(parser, "n", "", {'n'});
+        args::PositionalList<std::string> pos(parser, "pos", "");
+        test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"-n", "--", "x"}); });
+    }
+
+    // Once the minimum is satisfied, "--" still terminates and the following
+    // arguments become positionals.
+    {
+        args::ArgumentParser parser("Test command");
+        args::NargsValueFlag<std::string> n(parser, "n", "", {'n'}, {1, 4});
+        args::PositionalList<std::string> pos(parser, "pos", "");
+        test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"-n", "a", "b", "--", "c", "d"}); });
+        test::require((*n == std::vector<std::string>{"a", "b"}));
+        test::require((*pos == std::vector<std::string>{"c", "d"}));
+    }
+
+    return 0;
+}


### PR DESCRIPTION
**`--` terminator swallowed while a flag is still gathering values**

While a flag is still below its minimum argument count, `ParseArgsValues` takes the next token without checking it against the terminator, so `--` and the positionals after it are consumed as values. A `NargsValueFlag` with `Nargs{2, 4}` given `-n a -- b c` yields `n = ["a", "--", "b", "c"]` with an empty positional list, and a plain `ValueFlag` given `-n -- x` stores `"--"`; the README documents `--` as forcing following arguments to be positional, so both contradict that. The collection loop now stops at the terminator, matching the main parse loop, with regression tests for the throwing and noexcept paths.