### PR TITLE
recognise short flags when the long prefix is empty

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2576,12 +2576,26 @@ namespace args
 
             OptionType ParseOption(const std::string &s, bool allowEmpty = false)
             {
-                if (s.find(longprefix) == 0 && (allowEmpty || s.length() > longprefix.length()))
+                const bool matchesLong = s.find(longprefix) == 0 && (allowEmpty || s.length() > longprefix.length());
+                const bool matchesShort = s.find(shortprefix) == 0 && (allowEmpty || s.length() > shortprefix.length());
+
+                // A chunk can start with both prefixes when one is a prefix of
+                // the other, or when the long prefix is empty (every string
+                // starts with it). Resolve to the longer, more specific prefix:
+                // this keeps the default "--"/"-" preference for long flags
+                // while letting a short flag be recognised under an empty long
+                // prefix instead of being swallowed as a nameless long flag.
+                if (matchesLong && matchesShort)
+                {
+                    return longprefix.length() >= shortprefix.length() ? OptionType::LongFlag : OptionType::ShortFlag;
+                }
+
+                if (matchesLong)
                 {
                     return OptionType::LongFlag;
                 }
 
-                if (s.find(shortprefix) == 0 && (allowEmpty || s.length() > shortprefix.length()))
+                if (matchesShort)
                 {
                     return OptionType::ShortFlag;
                 }

--- a/test/empty_longprefix_short_flags.cxx
+++ b/test/empty_longprefix_short_flags.cxx
@@ -1,0 +1,53 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    // With an empty long prefix the long form carries no prefix, but a short
+    // flag must still be reachable through the (non-empty) short prefix rather
+    // than being swallowed as a nameless long flag.
+    {
+        args::ArgumentParser parser("This is a test program.");
+        parser.ShortPrefix("-");
+        parser.LongPrefix("");
+        parser.LongSeparator("=");
+        args::ValueFlag<int> counter(parser, "integer", "The counter value", {'c', "counter"});
+        args::Flag verbose(parser, "verbose", "Verbose output", {'v', "verbose"});
+        parser.ParseArgs(std::vector<std::string>{"-v", "-c", "3"});
+        test::require(verbose);
+        test::require(counter);
+        test::require(*counter == 3);
+    }
+
+    // The prefix-less long form keeps working unchanged.
+    {
+        args::ArgumentParser parser("This is a test program.");
+        parser.ShortPrefix("-");
+        parser.LongPrefix("");
+        parser.LongSeparator("=");
+        args::ValueFlag<int> counter(parser, "integer", "The counter value", {'c', "counter"});
+        parser.ParseArgs(std::vector<std::string>{"counter=7"});
+        test::require(counter);
+        test::require(*counter == 7);
+    }
+
+    // The default "--"/"-" configuration is unaffected: a chunk starting with
+    // both prefixes still resolves to the longer (long) one.
+    {
+        args::ArgumentParser parser("This is a test program.");
+        args::Flag foo(parser, "foo", "The foo flag", {"foo"});
+        args::Flag f(parser, "f", "The f flag", {'f'});
+        parser.ParseArgs(std::vector<std::string>{"--foo", "-f"});
+        test::require(foo);
+        test::require(f);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
**Short flags ignored under an empty long prefix**

`ParseOption` checks the long prefix first, and an empty long prefix is a prefix of every argument, so a chunk like `-c` is taken as a nameless long flag and never reaches short matching (issue #94: with `ShortPrefix("-")` and an empty `LongPrefix`, `-c 3` fails with "Flag could not be matched: -c" while the prefix-less `counter=3` works). A chunk that starts with both prefixes now resolves to the longer, more specific one, so the default `--`/`-` behaviour is unchanged while a short flag stays reachable when the long prefix is the shorter of the two.