### PR TITLE
skip flag and command completions past the -- terminator

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2902,7 +2902,7 @@ namespace args
             }
 
             template <typename It>
-            bool Complete(It it, It end)
+            bool Complete(It it, It end, bool terminated)
             {
                 auto nextIt = it;
                 if (!readCompletion || (++nextIt != end))
@@ -2915,7 +2915,11 @@ namespace args
                 std::vector<Command *> commands = GetCommands();
                 const auto optionType = ParseOption(chunk, true);
 
-                if (!commands.empty() && (chunk.empty() || optionType == OptionType::Positional))
+                // Once the terminator has been seen the parser treats every
+                // following chunk as positional, so only positional choices are
+                // valid completions here. Suggesting flags or commands past the
+                // terminator offers candidates the parser would then reject.
+                if (!terminated && !commands.empty() && (chunk.empty() || optionType == OptionType::Positional))
                 {
                     for (auto &cmd : commands)
                     {
@@ -2928,7 +2932,7 @@ namespace args
                 {
                     bool hasPositionalCompletion = true;
 
-                    if (!commands.empty())
+                    if (!terminated && !commands.empty())
                     {
                         for (auto &cmd : commands)
                         {
@@ -2950,7 +2954,7 @@ namespace args
                         }
                     }
 
-                    if (hasPositionalCompletion)
+                    if (!terminated && hasPositionalCompletion)
                     {
                         auto flags = GetAllFlags();
                         for (auto flag : flags)
@@ -3034,7 +3038,7 @@ namespace args
                 // Check all arg chunks
                 for (auto it = begin; it != end; ++it)
                 {
-                    if (Complete(it, end))
+                    if (Complete(it, end, terminated))
                     {
                         return end;
                     }

--- a/test/completion_terminator.cxx
+++ b/test/completion_terminator.cxx
@@ -1,0 +1,38 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    args::ArgumentParser p("parser");
+    args::CompletionFlag c(p, {"completion"});
+    args::Flag f(p, "foo", "description", {'f', "foo"});
+    args::MapPositional<std::string, int> mp(p, "mp", "description", {{"alpha", 1}, {"beta", 2}});
+
+    // Without a terminator both the positional choices and the flag are offered.
+    test::require_throws_with([&] { p.ParseArgs(std::vector<std::string>{"--completion", "bash", "1", "test", ""}); }, "alpha\nbeta\n-f");
+
+    // After the -- terminator the parser treats every following chunk as
+    // positional, so only positional choices remain; flags are no longer valid
+    // candidates and must not be suggested.
+    test::require_throws_with([&] { p.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "--", ""}); }, "alpha\nbeta");
+    test::require_throws_with([&] { p.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "--", "a"}); }, "alpha");
+    test::require_throws_with([&] { p.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "--", "-"}); }, "");
+    test::require_throws_with([&] { p.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "--", "--"}); }, "");
+
+    args::ArgumentParser p2("parser");
+    args::CompletionFlag c2(p2, {"completion"});
+    args::Command command1(p2, "command1", "desc", [](args::Subparser &sp) { sp.Parse(); });
+    args::Command command2(p2, "command2", "desc", [](args::Subparser &sp) { sp.Parse(); });
+
+    // Commands are offered normally, but not once the terminator has been seen.
+    test::require_throws_with([&] { p2.ParseArgs(std::vector<std::string>{"--completion", "bash", "1", "test", ""}); }, "command1\ncommand2");
+    test::require_throws_with([&] { p2.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "--", ""}); }, "");
+    return 0;
+}

--- a/test/noexcept_completion_terminator.cxx
+++ b/test/noexcept_completion_terminator.cxx
@@ -1,0 +1,34 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#define ARGS_NOEXCEPT
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    args::ArgumentParser p("parser");
+    args::CompletionFlag c(p, {"completion"});
+    args::Flag f(p, "foo", "description", {'f', "foo"});
+    args::MapPositional<std::string, int> mp(p, "mp", "description", {{"alpha", 1}, {"beta", 2}});
+
+    p.ParseArgs(std::vector<std::string>{"--completion", "bash", "1", "test", ""});
+    test::require(p.GetError() == args::Error::Completion);
+    test::require(args::get(c) == "alpha\nbeta\n-f");
+
+    // After the -- terminator only positional choices remain; flags are not
+    // offered because the parser would treat the chunk as positional.
+    p.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "--", ""});
+    test::require(p.GetError() == args::Error::Completion);
+    test::require(args::get(c) == "alpha\nbeta");
+
+    p.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "--", "-"});
+    test::require(p.GetError() == args::Error::Completion);
+    test::require(args::get(c).empty());
+
+    return 0;
+}


### PR DESCRIPTION
**Flag completions leak past the `--` terminator**

Completing `prog -- -<TAB>` still suggests `-f`/`--foo`, and with subcommands `prog -- <TAB>` still suggests commands, though the parser treats every chunk after `--` as positional and would reject those candidates. `Complete` never consulted the parse loop's `terminated` state; passing it in gates the flag and command suggestions while leaving positional-choice completion untouched.