### PR TITLE
Added GetFilteredChildren function to Group class

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -1800,6 +1800,29 @@ namespace args
                 return matched_children;
             }
 
+            /** Gets the children which are a certain type.
+              * \tparam ChildType The type of child to select. 
+              * \param matching Return only children of the type which matched (default false).
+              * \return Vector of children meeting the criteria.
+             */
+             template <typename ChildType>
+             std::vector<ChildType *> GetFilteredChildren(bool matching = false) const
+             {
+                std::vector<ChildType *> filtered_children;
+                for(Base *child : children) {
+                    if(!matching || child->Matched())
+                    {
+                        ChildType* cast_result = dynamic_cast<ChildType*>(child);
+                        if(cast_result != nullptr)
+                        {
+                            filtered_children.push_back(cast_result);
+                        }
+
+                    }
+                }
+                return filtered_children;
+             }
+
             /** Whether or not this group matches validation
              */
             virtual bool Matched() const noexcept override

--- a/test/group_get_filtered.cxx
+++ b/test/group_get_filtered.cxx
@@ -1,0 +1,38 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+using StrPositional = args::Positional<std::string>;
+
+int main()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Flag flag_a(parser, "a", "test flag", {'a'});
+    args::Flag flag_b(parser, "b", "test flag", {'b'});
+    StrPositional position_1(parser, "first", "test positional");
+    StrPositional position_2(parser, "second", "test positional");
+    
+    parser.ParseArgs(std::vector<std::string>{"-a", "first"});
+    
+    auto allFlags = parser.GetFilteredChildren<args::Flag>();
+    test::require(allFlags.size() == 2);
+    test::require_contains(allFlags, &flag_a);
+    test::require_contains(allFlags, &flag_b);
+
+    auto matchedFlags = parser.GetFilteredChildren<args::Flag>(true);
+    test::require(matchedFlags.size() == 1);
+    test::require(matchedFlags[0] == &flag_a);
+
+    auto allPositional = parser.GetFilteredChildren<StrPositional>();
+    test::require(allPositional.size() == 2);
+    test::require_contains(allPositional, &position_1);
+    test::require_contains(allPositional, &position_2);
+
+    auto matchedPositional = parser.GetFilteredChildren<StrPositional>(true);
+    test::require(matchedPositional.size() == 1);
+    test::require(matchedPositional[0] == &position_1);
+}

--- a/test/group_get_matches.cxx
+++ b/test/group_get_matches.cxx
@@ -2,16 +2,9 @@
  * This code is released under the license described in the LICENSE file
  */
 
-#include "test_common.hxx"
-
 #include <args.hxx>
 
 #include "test_helpers.hxx"
-
-inline void require_contains(const std::vector<args::Base *> vec, const args::Flag *target)
-{
-    test::require(std::find(vec.begin(), vec.end(), target) != vec.end());
-}
 
 int main()
 {
@@ -43,7 +36,7 @@ int main()
     parser.ParseArgs(std::vector<std::string>{"-g", "-h", "-i"});
     auto allmatched = allgroup.GetMatchedChildren();
     test::require(allmatched.size() == 3);
-    require_contains(allmatched, &all_g);
-    require_contains(allmatched, &all_h);
-    require_contains(allmatched, &all_i);
+    test::require_contains(allmatched, &all_g);
+    test::require_contains(allmatched, &all_h);
+    test::require_contains(allmatched, &all_i);
 }

--- a/test/test_helpers.hxx
+++ b/test/test_helpers.hxx
@@ -101,6 +101,12 @@ void require_throws_with(F &&f, const std::string &expected)
     fail("require_throws_with: nothing thrown");
 }
 
+template <typename ContainerT, typename TargetT>
+void require_contains(const ContainerT& container, const TargetT& target)
+{
+    test::require(std::find(container.begin(), container.end(), target) != container.end());
+}
+
 } // namespace test
 
 #endif


### PR DESCRIPTION
Added a new template function `GetFilteredChildren` which returns a vector of children of a group which are a specific child type. The function also takes a parameter to return only matched children of that type.

This is useful for retrieving, for example, only Flags, and getting a vector of that type rather than needing to cast Base pointers.

This also adds the function `require_contains` to the unit testing header, and updates the unit test for GetMatchedChildren to use the header version instead of its inline one.