### PR TITLE
Constant flag

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -4114,6 +4114,43 @@ namespace args
             }
     };
 
+    /** A boolean flag containing a retrievable constant.
+     * 
+     * \tparam T the type of the constant
+     */
+    template <typename T>
+    class ConstantFlag : public Flag
+    {
+        T value;
+
+        public:
+
+        ConstantFlag(Group &group_, const std::string &name_, const std::string &help_, Matcher &&matcher_, Options options_, const T& value):
+        Flag(group_, name_, help_, std::move(matcher_), options_),
+        value(value)
+        {}
+
+        ConstantFlag(Group &group_, const std::string &name_, const std::string &help_, Matcher &&matcher_, const T& value, bool extraError = false):
+        Flag(group_, name_, help_, std::move(matcher_), extraError),
+        value(value)
+        {}
+
+        T operator * () const noexcept
+        {
+            return value;
+        }
+
+        T Get() const noexcept
+        {
+            return value;
+        }
+
+        T *operator -> () const noexcept
+        {
+            return &value;
+        }
+    };
+
     /** A variadic arguments accepting flag class
      *
      * \tparam T the type to extract the argument as

--- a/args.hxx
+++ b/args.hxx
@@ -4125,14 +4125,14 @@ namespace args
 
         public:
 
-        ConstantFlag(Group &group_, const std::string &name_, const std::string &help_, Matcher &&matcher_, Options options_, const T& value):
+        ConstantFlag(Group &group_, const std::string &name_, const std::string &help_, Matcher &&matcher_, Options options_, const T& value_):
         Flag(group_, name_, help_, std::move(matcher_), options_),
-        value(value)
+        value(value_)
         {}
 
-        ConstantFlag(Group &group_, const std::string &name_, const std::string &help_, Matcher &&matcher_, const T& value, bool extraError = false):
-        Flag(group_, name_, help_, std::move(matcher_), extraError),
-        value(value)
+        ConstantFlag(Group &group_, const std::string &name_, const std::string &help_, Matcher &&matcher_, const T& value_, bool extraError_ = false):
+        Flag(group_, name_, help_, std::move(matcher_), extraError_),
+        value(value_)
         {}
 
         T operator * () const noexcept

--- a/test/constant_flag.cxx
+++ b/test/constant_flag.cxx
@@ -8,22 +8,51 @@
 
 #include "test_helpers.hxx"
 
-using IntFlag = args::ConstantFlag<int>;
+enum class LogLevel {
+    ERROR,
+    WARNING
+};
+
+using LogFlag = args::ConstantFlag<LogLevel>;
 
 int main()
 {
     args::ArgumentParser parser("This is a test program.", "This goes after the options.");
-    IntFlag flagA(parser, "A", "test flag", {'a', "flaga"}, 7);
-    IntFlag flagB(parser, "B", "test flag". {'b', "flagb"}, 11);
-
-    parser.ParseArgs(std::vector<std::string>{"-a"});
-
-    auto matched = parser.GetMatchedChildren();
-    test::require(matched.size() == 2);
-    test::require(((IntFlag)matched[0]).Get() == 7);
-    test::require(*((IntFlag)matched[0]) == 7);
-    test::require(*((IntFlag)matched[1]).Get() == 11);
-    test::require(*((IntFlag)matched[1]).Get() == 11);
+    args::Group logLevels(parser, "This is a test group.", args::Group::Validators::AtMostOne);
+    LogFlag error(logLevels, "error", "test constant flag", {'e', "error"}, LogLevel::ERROR);
+    LogFlag warning(logLevels, "warning", "test constant flag", {'w', "warning"}, LogLevel::WARNING);
     
+    parser.ParseArgs(std::vector<std::string>{});
+    auto noMatches = logLevels.GetFilteredChildren<LogFlag>(true);
+    test::require(noMatches.empty());
+
+    parser.Reset();
+    parser.ParseArgs(std::vector<std::string>{"-e"});
+    auto shortErrorMatches = logLevels.GetFilteredChildren<LogFlag>(true);
+    test::require(shortErrorMatches.size() == 1);
+    test::require(shortErrorMatches[0]->Get() == LogLevel::ERROR);
+    test::require(**(shortErrorMatches[0]) == LogLevel::ERROR);
+
+    parser.Reset();
+    parser.ParseArgs(std::vector<std::string>{"--error"});
+    auto longErrorMatches = logLevels.GetFilteredChildren<LogFlag>(true);
+    test::require(longErrorMatches.size() == 1);
+    test::require(longErrorMatches[0]->Get() == LogLevel::ERROR);
+    test::require(**(longErrorMatches[0]) == LogLevel::ERROR);
+
+    parser.Reset();
+    parser.ParseArgs(std::vector<std::string>{"-w"});
+    auto shortWarningMatches = logLevels.GetFilteredChildren<LogFlag>(true);
+    test::require(shortWarningMatches.size() == 1);
+    test::require(shortWarningMatches[0]->Get() == LogLevel::WARNING);
+    test::require(**(shortWarningMatches[0]) == LogLevel::WARNING);
+
+    parser.Reset();
+    parser.ParseArgs(std::vector<std::string>{"--warning"});
+    auto longWarningMatches = logLevels.GetFilteredChildren<LogFlag>(true);
+    test::require(longWarningMatches.size() == 1);
+    test::require(longWarningMatches[0]->Get() == LogLevel::WARNING);
+    test::require(**(longWarningMatches[0]) == LogLevel::WARNING);
+
     return 0;
 }

--- a/test/constant_flag.cxx
+++ b/test/constant_flag.cxx
@@ -1,0 +1,29 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+using IntFlag = args::ConstantFlag<int>;
+
+int main()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    IntFlag flagA(parser, "A", "test flag", {'a', "flaga"}, 7);
+    IntFlag flagB(parser, "B", "test flag". {'b', "flagb"}, 11);
+
+    parser.ParseArgs(std::vector<std::string>{"-a"});
+
+    auto matched = parser.GetMatchedChildren();
+    test::require(matched.size() == 2);
+    test::require(((IntFlag)matched[0]).Get() == 7);
+    test::require(*((IntFlag)matched[0]) == 7);
+    test::require(*((IntFlag)matched[1]).Get() == 11);
+    test::require(*((IntFlag)matched[1]).Get() == 11);
+    
+    return 0;
+}


### PR DESCRIPTION
Adds a new type of flag wrapping a constant value.

This is useful for quickly determining results of a set of mutually exclusive values, without needing to compare a result set against each existing flag. The test shows a simple example of configuring a logging level without needing to compare against each possible level.