### PR TITLE
Fix for duplicate arguments bug 117

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -1072,6 +1072,11 @@ namespace args
                 return false;
             }
 
+            virtual bool IsFlag() const
+            {
+                return false;
+            }
+
             virtual FlagBase *Match(const EitherFlag &)
             {
                 return nullptr;
@@ -1338,6 +1343,11 @@ namespace args
 
             virtual ~FlagBase() {}
 
+            virtual bool IsFlag() const override
+            {
+                return true;
+            }
+
             virtual FlagBase *Match(const EitherFlag &flag) override
             {
                 if (matcher.Match(flag))
@@ -1410,8 +1420,21 @@ namespace args
 
 #ifdef ARGS_NOEXCEPT
             /// Only for ARGS_NOEXCEPT
+            bool usageError = false;
+            void SetUsageError()
+            {
+                usageError = true;
+            }
+            void ClearUsageError()
+            {
+                usageError = false;
+            }
             virtual Error GetError() const override
             {
+                if(usageError)
+                {
+                    return Error::Usage;
+                }
                 const auto nargs = NumberOfArguments();
                 if (nargs.min > nargs.max)
                 {
@@ -1622,6 +1645,7 @@ namespace args
     class Group : public Base
     {
         private:
+            Group* parent;
             std::vector<Base*> children;
             std::function<bool(const Group &)> validator;
 
@@ -1678,11 +1702,15 @@ namespace args
                 }
             };
             /// If help is empty, this group will not be printed in help output
-            Group(const std::string &help_ = std::string(), const std::function<bool(const Group &)> &validator_ = Validators::DontCare, Options options_ = {}) : Base(help_, options_), validator(validator_) {}
+            Group(const std::string &help_ = std::string(), const std::function<bool(const Group &)> &validator_ = Validators::DontCare, Options options_ = {}) : Base(help_, options_), validator(validator_)
+            {
+                parent = nullptr;
+            }
             /// If help is empty, this group will not be printed in help output
             Group(Group &group_, const std::string &help_ = std::string(), const std::function<bool(const Group &)> &validator_ = Validators::DontCare, Options options_ = {}) : Base(help_, options_), validator(validator_)
             {
                 group_.Add(*this);
+                parent = &group_;
             }
             virtual ~Group() {}
 
@@ -1691,6 +1719,10 @@ namespace args
             void Add(Base &child)
             {
                 children.emplace_back(&child);
+
+                if(child.IsFlag()) {
+                    SignalDetectDuplicates();
+                }
             }
 
             /** Get all this group's children
@@ -1916,6 +1948,77 @@ namespace args
                 error = Error::None;
                 errorMsg.clear();
 #endif
+            }
+
+            /** Sends a signal to the root of the tree to begin checking for
+              * duplicates. If this is the root, begins checking.
+              */
+            void SignalDetectDuplicates()
+            {
+                if(parent != nullptr) parent->SignalDetectDuplicates();
+                else DetectDuplicateFlags();
+            }
+
+            /** Detect duplicate flags.
+              * In a noexcept context, sets an error on the duplicate flag.
+              * In a normal context, throws a ParseError.
+              */
+            void DetectDuplicateFlags()
+            {
+                std::unordered_set<char> usedShortFlags;
+                std::unordered_set<std::string> usedLongFlags;
+                DetectDuplicateFlags(usedShortFlags, usedLongFlags);
+            }
+        
+            /** Used by parameterless DetectDuplicateFlags.
+              */
+            void DetectDuplicateFlags(std::unordered_set<char> &usedShortFlags, std::unordered_set<std::string> &usedLongFlags)
+            {
+                for (Base *child: Children())
+                {
+                    if(auto flag = dynamic_cast<FlagBase*>(child))
+                    {
+                        // Check for duplicate flags, setting a usage error on the
+                        // flag if a duplicate is detected.
+                        for(EitherFlag flagString: flag->GetMatcher().GetFlagStrings())
+                        {
+                            if(flagString.isShort)
+                            {
+                                if(usedShortFlags.count(flagString.shortFlag))
+                                {
+#ifdef ARGS_NOEXCEPT
+                                    flag->SetUsageError();
+#else
+                                    throw ParseError("duplicate short flag detected");
+#endif
+                                }
+                                else
+                                {
+                                    usedShortFlags.insert(flagString.shortFlag);
+                                }
+                            }
+                            else
+                            {
+                                if(usedLongFlags.count(flagString.longFlag))
+                                {
+#ifdef ARGS_NOEXCEPT
+                                    flag->SetUsageError();
+#else
+                                    throw ParseError("duplicate long flag detected");
+#endif
+                                }
+                                else
+                                {
+                                    usedLongFlags.insert(flagString.longFlag);
+                                }
+                            }
+                        }
+                    }
+                    else if(auto group = dynamic_cast<Group*>(child))
+                    {
+                        group->DetectDuplicateFlags(usedShortFlags, usedLongFlags);
+                    }
+                }
             }
 
 #ifdef ARGS_NOEXCEPT

--- a/test/detect_duplicate_flags.cxx
+++ b/test/detect_duplicate_flags.cxx
@@ -1,0 +1,82 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+void testDuplicateShort()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Flag flag_aone(parser, "aone", "test flag", {'a', "aone"});
+    test::require_throws_as<args::ParseError>([&]{
+        args::Flag flag_atwo(parser, "atwo", "test flag", {'a', "atwo"});
+    });
+}
+
+void testDuplicateLong()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Flag flag_a(parser, "aflag", "test flag", {'a', "flag"});
+    test::require_throws_as<args::ParseError>([&]{
+        args::Flag flag_b(parser, "bflag", "test flag", {'b', "flag"});
+    });
+}
+
+void testDuplicateShortInGroup()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Group group(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_aone(group, "aone", "test flag", {'a', "aone"});
+    test::require_throws_as<args::ParseError>([&]{
+        args::Flag flag_atwo(group, "atwo", "test flag", {'a', "atwo"});
+    });
+}
+
+void testDuplicateLongInGroup()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Group group(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_a(group, "aflag", "test flag", {'a', "flag"});
+    test::require_throws_as<args::ParseError>([&]{
+        args::Flag flag_b(group, "bflag", "test flag", {'b', "flag"});
+    });
+}
+
+void testDuplicateShortInTwoGroups()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Group group1(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_a(group1, "a", "test flag", {'a', "flaga"});
+    args::Flag flag_b(group1, "b", "test flag", {'b', "flagb"});
+    args::Group group2(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_c(group2, "c", "test flag", {'c', "flagc"});
+    test::require_throws_as<args::ParseError>([&]{
+        args::Flag flag_d(group2, "d", "test flag", {'b', "flagd"});
+    });
+}
+
+void testDuplicateLongInTwoGroups()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Group group1(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_a(group1, "a", "test flag", {'a', "flaga"});
+    args::Flag flag_b(group1, "b", "test flag", {'b', "flagb"});
+    args::Group group2(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_c(group1, "c", "test flag", {'c', "flagc"});
+    test::require_throws_as<args::ParseError>([&]{
+        args::Flag flag_d(group1, "d", "test flag", {'d', "flagb"});
+    });
+}
+
+int main()
+{
+    testDuplicateShort();
+    testDuplicateLong();
+    testDuplicateShortInGroup();
+    testDuplicateLongInGroup();
+    testDuplicateShortInTwoGroups();
+    testDuplicateLongInTwoGroups();
+
+}

--- a/test/detect_duplicate_flags_noexcept.cxx
+++ b/test/detect_duplicate_flags_noexcept.cxx
@@ -1,0 +1,75 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+#define ARGS_NOEXCEPT
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+void testDuplicateShort()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Flag flag_aone(parser, "aone", "test flag", {'a', "aone"});
+    args::Flag flag_atwo(parser, "atwo", "test flag", {'a', "atwo"});
+    test::require(parser.GetError() == args::Error::Usage);
+}
+
+void testDuplicateLong()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Flag flag_a(parser, "aflag", "test flag", {'a', "flag"});
+    args::Flag flag_b(parser, "bflag", "test flag", {'b', "flag"});
+    test::require(parser.GetError() == args::Error::Usage);
+}
+
+void testDuplicateShortInGroup()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Group group(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_aone(group, "aone", "test flag", {'a', "aone"});
+    args::Flag flag_atwo(group, "atwo", "test flag", {'a', "atwo"});
+    test::require(parser.GetError() == args::Error::Usage);
+}
+
+void testDuplicateLongInGroup()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Group group(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_a(group, "aflag", "test flag", {'a', "flag"});
+    args::Flag flag_b(group, "bflag", "test flag", {'b', "flag"});
+    test::require(parser.GetError() == args::Error::Usage);
+}
+
+void testDuplicateShortInTwoGroups()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Group group1(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_a(group1, "a", "test flag", {'a', "flaga"});
+    args::Flag flag_b(group1, "b", "test flag", {'b', "flagb"});
+    args::Group group2(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_c(group2, "c", "test flag", {'c', "flagc"});
+    args::Flag flag_d(group2, "d", "test flag", {'b', "flagd"});
+    test::require(parser.GetError() == args::Error::Usage);
+}
+
+void testDuplicateLongInTwoGroups()
+{
+    args::ArgumentParser parser("This is a test program.", "This goes after the options.");
+    args::Group group1(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_a(group1, "a", "test flag", {'a', "flaga"});
+    args::Flag flag_b(group1, "b", "test flag", {'b', "flagb"});
+    args::Group group2(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_c(group1, "c", "test flag", {'c', "flagc"});
+    args::Flag flag_d(group1, "d", "test flag", {'d', "flagb"});
+    test::require(parser.GetError() == args::Error::Usage);
+}
+
+int main()
+{
+    testDuplicateShort();
+    testDuplicateLong();
+    testDuplicateShortInGroup();
+    testDuplicateLongInGroup();
+    testDuplicateShortInTwoGroups();
+    testDuplicateLongInTwoGroups();
+}

--- a/test/hidden_options.cxx
+++ b/test/hidden_options.cxx
@@ -14,17 +14,17 @@ int main()
     args::ValueFlag<int> foo(parser1, "foo", "foo", {'f', "foo"}, args::Options::HiddenFromDescription);
     args::ValueFlag<int> bar(parser1, "bar", "bar", {'b'}, args::Options::HiddenFromUsage);
     args::Group group(parser1, "group");
-    args::ValueFlag<int> foo1(group, "foo", "foo", {'f', "foo"}, args::Options::Hidden);
-    args::ValueFlag<int> bar2(group, "bar", "bar", {'b'});
+    args::ValueFlag<int> foo1(group, "goo", "goo", {'g', "goo"}, args::Options::Hidden);
+    args::ValueFlag<int> bar2(group, "car", "car", {'c'});
 
     auto desc = parser1.GetDescription(parser1.helpParams, 0);
     test::require(desc.size() == 3);
     test::require(std::get<0>(desc[0]) == "-b[bar]");
     test::require(std::get<0>(desc[1]) == "group");
-    test::require(std::get<0>(desc[2]) == "-b[bar]");
+    test::require(std::get<0>(desc[2]) == "-c[car]");
 
     parser1.helpParams.proglineShowFlags = true;
     parser1.helpParams.proglinePreferShortFlags = true;
-    test::require((parser1.GetProgramLine(parser1.helpParams) == std::vector<std::string>{"[-f <foo>]", "[-b <bar>]"}));
+    test::require((parser1.GetProgramLine(parser1.helpParams) == std::vector<std::string>{"[-f <foo>]", "[-c <car>]"}));
     return 0;
 }


### PR DESCRIPTION
Fixes #117 by searching the tree for duplicate arguments on parse.

Normal context throws a `ParseError` if a duplicate is found.
Noexcept context sets a `UsageError` if a duplicate is found.