### PR TITLE
honour joined-value separation for optional-argument flags

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2679,14 +2679,14 @@ namespace args
 
                 Nargs nargs = flag.NumberOfArguments();
 
-                if (hasJoined && !allowJoined && nargs.min != 0)
+                if (hasJoined && !allowJoined && (nargs.min != 0 || !canDiscardJoined))
                 {
                     return "Flag '" + arg + "' was passed a joined argument, but these are disallowed";
                 }
 
                 if (hasJoined)
                 {
-                    if (!canDiscardJoined || nargs.max != 0)
+                    if (!canDiscardJoined || (allowJoined && nargs.max != 0))
                     {
                         values.push_back(joinedArg);
                     }

--- a/test/optional_value_separation.cxx
+++ b/test/optional_value_separation.cxx
@@ -1,0 +1,51 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    // Flags with an optional argument (Nargs min == 0) must honour
+    // SetArgumentSeparations the same way a mandatory-argument ValueFlag does.
+    // Previously the joined-argument check was skipped whenever nargs.min == 0,
+    // so a disabled joined value slipped through for ImplicitValueFlag and
+    // NargsValueFlag{0, k}.
+    {
+        args::ArgumentParser parser("This is a test program.");
+        args::ImplicitValueFlag<int> jobs(parser, "N", "jobs", {'j', "jobs"}, 8, 0);
+        parser.SetArgumentSeparations(true, false, true, true);
+        test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"--jobs=7"}); });
+        test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"--jobs"}); });
+        test::require(*jobs == 8);
+        test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"--jobs", "3"}); });
+        test::require(*jobs == 3);
+    }
+    {
+        args::ArgumentParser parser("This is a test program.");
+        args::ImplicitValueFlag<int> jobs(parser, "N", "jobs", {'j', "jobs"}, 8, 0);
+        parser.SetArgumentSeparations(false, true, true, true);
+        test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"-j7"}); });
+    }
+    {
+        args::ArgumentParser parser("This is a test program.");
+        args::NargsValueFlag<std::string> nums(parser, "N", "nums", {'n', "nums"}, args::Nargs{0, 2});
+        parser.SetArgumentSeparations(true, false, true, true);
+        test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"--nums=5"}); });
+    }
+    // Joined values are still accepted when enabled (the default), so the fix
+    // does not regress the normal optional-argument behaviour.
+    {
+        args::ArgumentParser parser("This is a test program.");
+        args::ImplicitValueFlag<int> jobs(parser, "N", "jobs", {'j', "jobs"}, 8, 0);
+        test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"--jobs=7"}); });
+        test::require(*jobs == 7);
+        test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"-j5"}); });
+        test::require(*jobs == 5);
+    }
+    return 0;
+}


### PR DESCRIPTION
parseargsvalues decides whether a joined argument is allowed by testing nargs.min, so any flag with an optional argument (implicitvalueflag, or a nargsvalueflag whose minimum is zero) never reaches the "joined argument disallowed" branch that setargumentseparations is meant to enforce. with joined long values switched off, --jobs=7 is still accepted, and -j7 slips through with joined short values off, even though the mandatory-argument valueflag in the same configuration throws as documented in test/argument_separation.cxx. the behaviour now keys off whether the joined value can be discarded rather than off the minimum, and the joined value is only pushed when joining is genuinely allowed, so optional-argument flags follow the same separation rules as every other flag. added a regression test that fails on master for both the long and short forms.
