### PR TITLE
fix const-correctness of ConstantFlag::operator->

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -4248,7 +4248,7 @@ namespace args
             return value;
         }
 
-        T *operator -> () const noexcept
+        const T *operator -> () const noexcept
         {
             return &value;
         }

--- a/test/constant_flag.cxx
+++ b/test/constant_flag.cxx
@@ -15,6 +15,11 @@ enum class LogLevel {
 
 using LogFlag = args::ConstantFlag<LogLevel>;
 
+struct Version {
+    int high;
+    int low;
+};
+
 int main()
 {
     args::ArgumentParser parser("This is a test program.", "This goes after the options.");
@@ -53,6 +58,20 @@ int main()
     test::require(longWarningMatches.size() == 1);
     test::require(longWarningMatches[0]->Get() == LogLevel::WARNING);
     test::require(**(longWarningMatches[0]) == LogLevel::WARNING);
+
+    // Reach into a class-typed constant through operator->. This instantiates
+    // ConstantFlag<T>::operator->, which the checks above never do because they
+    // use a ConstantFlag pointer (plain pointer arrow) rather than the flag
+    // object itself.
+    args::ArgumentParser versionParser("This is a test program.");
+    args::ConstantFlag<Version> stable(versionParser, "stable", "stable version", {'s', "stable"}, Version{2, 5});
+    versionParser.ParseArgs(std::vector<std::string>{"--stable"});
+    test::require(stable->high == 2);
+    test::require(stable->low == 5);
+    test::require((*stable).high == 2);
+
+    const args::ConstantFlag<Version> &constStable = stable;
+    test::require(constStable->low == 5);
 
     return 0;
 }


### PR DESCRIPTION
**Broken operator-> on ConstantFlag**

The arrow operator is a const member yet returns `&value` as a plain `T*`; inside a const method that address has type `const T*`, so the conversion is ill-formed and any `constantFlag->member` fails to compile. It stayed hidden because this is the only `operator->` on the class and the shipped test only reaches `Get()` through a `ConstantFlag` pointer, so the member operator is never instantiated.

Every other value type here already pairs a mutable `T*` overload with a const `const T*` one, and a constant only needs the const form, so returning `const T*` lines it up with the rest. The test now reaches into a struct-typed constant through the arrow, which fails to build on master and passes with the change.