### PR TITLE
allow nargs to work with joined values

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2807,7 +2807,7 @@ namespace args
                     {
                         return "Flag '" + arg + "' was passed a separate argument, but these are disallowed";
                     }
-                } else
+                }
                 {
                     auto valueIt = it;
                     ++valueIt;

--- a/test/nargs.cxx
+++ b/test/nargs.cxx
@@ -12,7 +12,7 @@ int main()
 {
     args::ArgumentParser parser("Test command");
     args::NargsValueFlag<int> a(parser, "", "", {'a'}, 2);
-    args::NargsValueFlag<int> b(parser, "", "", {'b'}, {2, 3});
+    args::NargsValueFlag<int> b(parser, "", "", {"b", 'b'}, {2, 3});
     args::NargsValueFlag<std::string> c(parser, "", "", {'c'}, {0, 2});
     args::NargsValueFlag<int> d(parser, "", "", {'d'}, {1, 3});
     args::Flag f(parser, "", "", {'f'});
@@ -28,13 +28,29 @@ int main()
 
     test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"-a", "1"}); });
     test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"-a1"}); });
-    test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"-a1", "2"}); });
+    test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"-a1", "2"}); });
 
     test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"-b", "1", "-2", "-f"}); });
     test::require((*b == std::vector<int>{1, -2}));
     test::require(f);
 
     test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"-b", "1", "2", "3"}); });
+    test::require((*b == std::vector<int>{1, 2, 3}));
+    test::require(!f);
+
+    test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"--b", "1", "-2", "-f"}); });
+    test::require((*b == std::vector<int>{1, -2}));
+    test::require(f);
+
+    test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"--b", "1", "2", "3"}); });
+    test::require((*b == std::vector<int>{1, 2, 3}));
+    test::require(!f);
+
+    test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"--b=1", "-2", "-f"}); });
+    test::require((*b == std::vector<int>{1, -2}));
+    test::require(f);
+
+    test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"--b=1", "2", "3"}); });
     test::require((*b == std::vector<int>{1, 2, 3}));
     test::require(!f);
 


### PR DESCRIPTION
This is an ugly fix, and makes Nargs able to be used with pretty weird and baffling semantics, but they're already weird and baffling, and it doesn't hurt the standard use-case.

closes #192