### PR TITLE
respect argument separations when collecting separate values

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -2808,6 +2808,12 @@ namespace args
                         return "Flag '" + arg + "' was passed a separate argument, but these are disallowed";
                     }
                 }
+
+                // Only gather separate values when they are allowed. A joined
+                // value that was discarded rather than taken (short chunks such
+                // as -nf when joined short values are off) means this flag isn't
+                // taking an argument here, so the rest of the chunk is flags.
+                if (allowSeparate && (!hasJoined || !values.empty()))
                 {
                     auto valueIt = it;
                     ++valueIt;

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,7 @@ test_names = [
   'arg_flags',
   'arg_to_non_arg_flag',
   'argument_separation',
+  'argument_separation_nargs',
   'bool_flags',
   'choices_description',
   'completion',

--- a/test/argument_separation_nargs.cxx
+++ b/test/argument_separation_nargs.cxx
@@ -1,0 +1,68 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    // Separate values must still be refused when SetArgumentSeparations turns
+    // them off, even for flags whose argument is optional (Nargs min == 0).
+    {
+        args::ArgumentParser parser("This is a test program.");
+        args::ImplicitValueFlag<int> jobs(parser, "N", "jobs", {'j', "jobs"}, 8, 0);
+        args::Positional<std::string> pos(parser, "POS", "positional");
+        parser.SetArgumentSeparations(true, true, true, false);
+        test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"--jobs", "3"}); });
+        test::require(args::get(jobs) == 8);
+        test::require(args::get(pos) == "3");
+    }
+    {
+        args::ArgumentParser parser("This is a test program.");
+        args::ImplicitValueFlag<int> jobs(parser, "N", "jobs", {'j', "jobs"}, 8, 0);
+        args::Positional<std::string> pos(parser, "POS", "positional");
+        parser.SetArgumentSeparations(true, true, false, true);
+        test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"-j", "3"}); });
+        test::require(args::get(jobs) == 8);
+        test::require(args::get(pos) == "3");
+    }
+
+    // A joined value doesn't license the remaining arguments to be picked up
+    // separately when separate values are disallowed.
+    {
+        args::ArgumentParser parser("This is a test program.");
+        args::NargsValueFlag<std::string> nums(parser, "N", "nums", {'n', "nums"}, args::Nargs{2, 3});
+        parser.SetArgumentSeparations(true, true, true, false);
+        test::require_throws_as<args::ParseError>([&] { parser.ParseArgs(std::vector<std::string>{"--nums=1", "2"}); });
+    }
+
+    // With joined short values off, -nf leaves the chunk to be parsed as flags,
+    // so n takes no argument and f is still matched.
+    {
+        args::ArgumentParser parser("This is a test program.");
+        args::NargsValueFlag<std::string> nums(parser, "N", "nums", {'n', "nums"}, args::Nargs{0, 2});
+        args::Flag f(parser, "f", "test flag", {'f'});
+        args::Positional<std::string> pos(parser, "POS", "positional");
+        parser.SetArgumentSeparations(false, true, true, true);
+        test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"-nf", "5"}); });
+        test::require(args::get(nums).empty());
+        test::require(bool(f));
+        test::require(args::get(pos) == "5");
+    }
+
+    // The default separations still let a joined value be followed by separate
+    // ones, which is what nargs needs.
+    {
+        args::ArgumentParser parser("This is a test program.");
+        args::NargsValueFlag<int> a(parser, "A", "a", {'a', "aa"}, 2);
+        test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"-a1", "2"}); });
+        test::require((args::get(a) == std::vector<int>{1, 2}));
+        test::require_nothrow([&] { parser.ParseArgs(std::vector<std::string>{"--aa=1", "2"}); });
+        test::require((args::get(a) == std::vector<int>{1, 2}));
+    }
+    return 0;
+}


### PR DESCRIPTION
**Separate values collected even when they are disallowed**

Dropping the `else` in e319b42 left the value-collection loop in `ParseArgsValues` running unconditionally, so `SetArgumentSeparations` no longer reaches it: with separate values off, `--jobs 3` on an `ImplicitValueFlag` takes `3` instead of leaving it positional, and `--nums=1 2` fills a `Nargs{2, 3}` flag. The awkward one is with joined short values off, where `-nf 5` now takes `5` as n's value, so `ParseShort` breaks out of the chunk and `f` is silently dropped with nothing reported. Gated the loop on separate values being allowed and on the joined value having actually been taken rather than discarded; the added test covers all three plus the joined-then-separate nargs case from e319b42, and fails on master.