### PR TITLE
keep detail::Join compilable with exceptions disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,12 @@ if (ARGS_BUILD_UNITTESTS)
         args_configure_test(${target_name})
         add_test(NAME ${test_name} COMMAND ${target_name})
     endforeach ()
+
+    # ARGS_NOEXCEPT exists so the header can be used where exceptions are off,
+    # so build this one with them off to keep that working.
+    if (NOT MSVC)
+        target_compile_options(argstest-no_exceptions PRIVATE -fno-exceptions)
+    endif ()
 endif()
 
 add_library(taywee::args ALIAS args)

--- a/args.hxx
+++ b/args.hxx
@@ -398,13 +398,7 @@ namespace args
             
             if (can_reserve && total > 0)
             {
-                try
-                {
-                    res.reserve(total);
-                }
-                catch (...) {
-                    // Fall back to default allocation
-                }
+                res.reserve(total);
             }
             
             bool first = true;

--- a/meson.build
+++ b/meson.build
@@ -103,4 +103,11 @@ endforeach
 test('multiple_inclusion', executable('argstest-multiple_inclusion',
   sources: ['test/multiple_inclusion.cxx', 'test/multiple_inclusion.aux.cxx'],
   dependencies: args_dep))
+
+# ARGS_NOEXCEPT exists so the header can be used where exceptions are off, so
+# build this one with them off to keep that working.
+test('no_exceptions', executable('argstest-no_exceptions',
+  sources: 'test/no_exceptions.cxx',
+  cpp_args: meson.get_compiler('cpp').get_supported_arguments('-fno-exceptions'),
+  dependencies: args_dep))
 endif

--- a/test/no_exceptions.cxx
+++ b/test/no_exceptions.cxx
@@ -1,0 +1,34 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ *
+ * Compiled with the compiler's exception support switched off (see
+ * CMakeLists.txt and meson.build), so anything in args.hxx that needs
+ * exceptions outside of the ARGS_NOEXCEPT guards breaks this test at compile
+ * time.
+ */
+
+#define ARGS_NOEXCEPT
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+int main()
+{
+    args::ArgumentParser p("parser");
+    args::CompletionFlag c(p, {"completion"});
+    args::Flag f(p, "foo", "description", {'f', "foo"});
+    args::MapFlag<std::string, int> m(p, "map", "description", {'m', "map"}, {{"alpha", 1}, {"beta", 2}});
+
+    p.ParseArgs(std::vector<std::string>{"--map", "beta", "-f"});
+    test::require(p.GetError() == args::Error::None);
+    test::require(args::get(m) == 2);
+
+    // Completion replies are assembled by args::detail::Join.
+    p.ParseArgs(std::vector<std::string>{"--completion", "bash", "2", "test", "--map", ""});
+    test::require(p.GetError() == args::Error::Completion);
+    test::require(args::get(c) == "alpha\nbeta");
+
+    return 0;
+}

--- a/test/test_helpers.hxx
+++ b/test/test_helpers.hxx
@@ -38,6 +38,10 @@ inline void require_false(bool cond)
     }
 }
 
+// The throwing helpers are unusable in a translation unit built without
+// exception support, and merely parsing them is an error there.
+#ifdef __cpp_exceptions
+
 template <typename F>
 void require_nothrow(F &&f)
 {
@@ -100,6 +104,8 @@ void require_throws_with(F &&f, const std::string &expected)
     }
     fail("require_throws_with: nothing thrown");
 }
+
+#endif
 
 template <typename ContainerT, typename TargetT>
 void require_contains(const ContainerT& container, const TargetT& target)


### PR DESCRIPTION
**Unguarded try/catch in detail::Join**

Every other `try`/`catch` in the header sits behind `#ifndef ARGS_NOEXCEPT`, so `-fno-exceptions -DARGS_NOEXCEPT` used to build; since the reserve guard landed it stops at args.hxx:401 with `cannot use 'try' with exceptions disabled` (6.4.16 compiles, 6.5.0 onwards does not). I dropped the guard rather than adding another `#ifndef`, since it only covers `res.reserve(total)` while the append loop below allocates the same memory unguarded, so it was not really buying anything.

The new `no_exceptions` test is built with exceptions off under both CMake and meson, so it fails to compile on master and passes here; the throwing helpers in `test_helpers.hxx` had to move behind `__cpp_exceptions` for it to use them.