### PR TITLE
roll back Group::Add when duplicate flag detection throws

### DIFF
--- a/args.hxx
+++ b/args.hxx
@@ -1715,7 +1715,24 @@ namespace args
                 children.emplace_back(&child);
 
                 if(child.IsFlag()) {
+#ifndef ARGS_NOEXCEPT
+                    // Detection runs from the child's own constructor, so a
+                    // duplicate throws before that constructor completes and the
+                    // child's storage is released while the stack unwinds. Undo
+                    // the registration first, or a caller that catches the error
+                    // leaves this group holding a pointer to a dead object.
+                    try
+                    {
+                        SignalDetectDuplicates();
+                    }
+                    catch (...)
+                    {
+                        children.pop_back();
+                        throw;
+                    }
+#else
                     SignalDetectDuplicates();
+#endif
                 }
             }
 
@@ -3392,8 +3409,11 @@ namespace args
 
             void AddCompletion(CompletionFlag &completionFlag)
             {
-                completion = &completionFlag;
+                // Only take the pointer once registration has succeeded: Add()
+                // throws on a duplicate flag, and the flag it was handed is
+                // gone by the time that error reaches the caller.
                 Add(completionFlag);
+                completion = &completionFlag;
             }
 
             /** The program name for help generation

--- a/meson.build
+++ b/meson.build
@@ -36,6 +36,7 @@ test_names = [
   'count_flag',
   'custom_types',
   'default_values',
+  'duplicate_flag_rollback',
   'extra_positionals',
   'get_assignable',
   'get_program_line',

--- a/test/duplicate_flag_rollback.cxx
+++ b/test/duplicate_flag_rollback.cxx
@@ -1,0 +1,74 @@
+/* Copyright (c) Taylor Richberger <taylor@axfive.net>
+ * This code is released under the license described in the LICENSE file
+ */
+
+#include "test_common.hxx"
+
+#include <args.hxx>
+
+#include "test_helpers.hxx"
+
+void testFailedFlagIsNotRegistered()
+{
+    args::ArgumentParser parser("This is a test program.");
+    args::Flag flag_a(parser, "aone", "test flag", {'a', "aone"});
+
+    const auto children = parser.Children().size();
+    test::require_throws_as<args::ParseError>([&]{
+        args::Flag flag_b(parser, "atwo", "test flag", {'a', "atwo"});
+    });
+    test::require(parser.Children().size() == children);
+}
+
+void testFailedFlagInGroupIsNotRegistered()
+{
+    args::ArgumentParser parser("This is a test program.");
+    args::Group group(parser, "This is a test group.", args::Group::Validators::DontCare);
+    args::Flag flag_a(group, "aone", "test flag", {'a', "aone"});
+
+    const auto children = group.Children().size();
+    test::require_throws_as<args::ParseError>([&]{
+        args::Flag flag_b(group, "atwo", "test flag", {'a', "atwo"});
+    });
+    test::require(group.Children().size() == children);
+}
+
+void testParserStillUsableAfterCaughtDuplicate()
+{
+    args::ArgumentParser parser("This is a test program.");
+    args::Flag flag_a(parser, "aone", "test flag", {'a', "aone"});
+    args::Positional<std::string> pos(parser, "pos", "test positional");
+
+    test::require_throws_as<args::ParseError>([&]{
+        args::Flag flag_b(parser, "atwo", "test flag", {'a', "atwo"});
+    });
+
+    test::require_nothrow([&]{ parser.ParseArgs(std::vector<std::string>{"-a", "value"}); });
+    test::require(bool(flag_a));
+    test::require(args::get(pos) == "value");
+    test::require_nothrow([&]{ (void)parser.Help(); });
+}
+
+void testFailedCompletionFlagIsNotRegistered()
+{
+    args::ArgumentParser parser("This is a test program.");
+    args::Flag flag_a(parser, "aone", "test flag", {'a', "complete"});
+
+    const auto children = parser.Children().size();
+    test::require_throws_as<args::ParseError>([&]{
+        args::CompletionFlag completion(parser, {"complete"});
+    });
+    test::require(parser.Children().size() == children);
+
+    // The parser must not be left pointing at the completion flag it rejected.
+    test::require_nothrow([&]{ parser.ParseArgs(std::vector<std::string>{"--complete"}); });
+    test::require(bool(flag_a));
+}
+
+int main()
+{
+    testFailedFlagIsNotRegistered();
+    testFailedFlagInGroupIsNotRegistered();
+    testParserStillUsableAfterCaughtDuplicate();
+    testFailedCompletionFlagIsNotRegistered();
+}


### PR DESCRIPTION
**Dangling child pointer when duplicate detection rejects a flag**

Detection runs from the new flag's own constructor, so on a collision the `ParseError` is thrown before that constructor finishes and the flag's storage goes away during the unwind, while `Group::Add` has already pushed the pointer into `children`. Catching the error and carrying on with the parser is then a use-after-free on the next `Reset`, `Parse` or `Help`.

`ArgumentParser::AddCompletion` has the same shape at a second site: it took the pointer before calling `Add`, so a rejected `CompletionFlag` left `ArgumentParser::completion` dangling too. Assigning after `Add` succeeds looks sufficient there, since `Add` never reads it.

**Reproduction**

```cpp
#include <args.hxx>
#include <vector>

int main()
{
    args::ArgumentParser parser("test");
    args::Flag a(parser, "a", "a flag", {'a', "alpha"});

    try
    {
        // Registered at run time, and happens to collide with a flag already
        // in the parser.
        new args::Flag(parser, "dup", "dup flag", {'a', "dup"});
    }
    catch (const args::Error &)
    {
    }

    parser.ParseArgs(std::vector<std::string>{"--alpha"});
}
```

Built with `-fsanitize=address` against master:

```
==86928==ERROR: AddressSanitizer: heap-use-after-free on address 0x611000000040
READ of size 8 at 0x611000000040 thread T0
    #0 in args::Group::Reset() args.hxx:1939
    #1 in args::Command::Reset() args.hxx:2651
    #2 in args::ArgumentParser::Reset() args.hxx:3632
    #3 in args::ArgumentParser::ParseArgs<...>(...) args.hxx:3647
    #5 in main repro.cxx:19

0x611000000040 is located 0 bytes inside of 216-byte region
freed by thread T0 here:
    #1 in main repro.cxx:13
previously allocated by thread T0 here:
    #1 in main repro.cxx:13
```

The `AddCompletion` half is needed on its own. Swapping the duplicate `Flag` above for `new args::CompletionFlag(parser, {"alpha"})` and applying only the `Group::Add` change still reports a use-after-free, this time on `completion->Matched()` in `Parse`. Both variants run clean with the two together.

`test/duplicate_flag_rollback.cxx` covers the part that is visible without a sanitiser: the group no longer keeps the rejected child, and the parser still parses afterwards. It fails on master.

Detection cannot throw under `ARGS_NOEXCEPT`, where it flags a usage error and the child is fully constructed, so the rollback sits behind `#ifndef ARGS_NOEXCEPT` and the `-fno-exceptions` build is unaffected.
